### PR TITLE
Fix and test for a bug that came up

### DIFF
--- a/lib/mini_magick.rb
+++ b/lib/mini_magick.rb
@@ -5,8 +5,8 @@ module MiniMagick
   class << self
     attr_accessor :processor
     attr_accessor :timeout
-    
-    
+
+
     # Experimental method for automatically selecting a processor
     # such as gm. Only works on *nix.
     #
@@ -119,7 +119,7 @@ module MiniMagick
 
     # Create a new MiniMagick::Image object
     #
-    # _DANGER_: The file location passed in here is the *working copy*. That is, it gets *modified*. 
+    # _DANGER_: The file location passed in here is the *working copy*. That is, it gets *modified*.
     # you can either copy it yourself or use the MiniMagick::Image.open(path) method which creates a
     # temporary file for you and protects your original!
     #
@@ -222,7 +222,7 @@ module MiniMagick
         begin
           FileUtils.copy_file(@path.sub(".#{format}", "-#{page}.#{format}"), @path)
         rescue => ex
-          raise MiniMagickError, "Unable to format to #{format}; #{ex}" unless File.exist?(@path)
+          raise MiniMagick::Error, "Unable to format to #{format}; #{ex}" unless File.exist?(@path)
         end
       end
     ensure
@@ -237,7 +237,7 @@ module MiniMagick
       run_command("mogrify", "-quality", "100", "#{path}[0]")
     end
 
-    # Writes the temporary file out to either a file location (by passing in a String) or by  
+    # Writes the temporary file out to either a file location (by passing in a String) or by
     # passing in a Stream that you can #write(chunk) to repeatedly
     #
     # @param output_to [IOStream, String] Some kind of stream object that needs to be read or a file path as a String
@@ -278,14 +278,14 @@ module MiniMagick
 
     # You can use multiple commands together using this method. Very easy to use!
     #
-    # @example 
+    # @example
     #   image.combine_options do |c|
     #     c.draw "image Over 0,0 10,10 '#{MINUS_IMAGE_PATH}'"
     #     c.thumbnail "300x500>"
     #     c.background background
     #   end
     #
-    # @yieldparam command [CommandBuilder] 
+    # @yieldparam command [CommandBuilder]
     def combine_options(&block)
       c = CommandBuilder.new('mogrify')
       block.call(c)

--- a/mini_magick.gemspec
+++ b/mini_magick.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.summary     = "Manipulate images with minimal use of memory via ImageMagick / GraphicsMagick"
   s.description = ""
-  
+
   s.authors     = ["Corey Johnson", "Hampton Catlin", "Peter Kieltyka"]
   s.email       = ["probablycorey@gmail.com", "hcatlin@gmail.com", "peter@nulayer.com"]
   s.homepage    = "http://github.com/probablycorey/mini_magick"
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.files        = Dir['README.rdoc', 'VERSION', 'MIT-LICENSE', 'Rakefile', 'lib/**/*']
   s.test_files   = Dir['test/**/*']
   s.require_path = 'lib'
-  
+
   s.add_runtime_dependency('subexec', ['~> 0.0.4'])
+  s.add_development_dependency('mocha', ['~> 0.9.9'])
 end

--- a/test/image_test.rb
+++ b/test/image_test.rb
@@ -1,5 +1,6 @@
 require 'rubygems'
 require 'test/unit'
+require 'mocha'
 require 'pathname'
 require 'stringio'
 require File.expand_path('../../lib/mini_magick', __FILE__)
@@ -50,7 +51,7 @@ class ImageTest < Test::Unit::TestCase
     image = Image.new(SIMPLE_IMAGE_PATH)
     image.destroy!
   end
-  
+
   def test_remote_image
     image = Image.open("http://www.google.com/images/logos/logo.png")
     image.valid?
@@ -229,7 +230,7 @@ class ImageTest < Test::Unit::TestCase
     end
     image.destroy!
   end
-  
+
   # http://github.com/probablycorey/mini_magick/issues#issue/15
   def test_issue_15
     image = Image.open(Pathname.new(SIMPLE_IMAGE_PATH))
@@ -248,4 +249,16 @@ class ImageTest < Test::Unit::TestCase
     end
     image.destroy!
   end
+
+  # testing that if copying files formatted from an animation fails,
+  # it raises an appropriate error
+  def test_throw_animation_copy_after_format_error
+    image = Image.open(ANIMATION_PATH)
+    FileUtils.stubs(:copy_file).raises(Errno::ENOENT)
+    assert_raises MiniMagick::Error do
+      image.format('png')
+    end
+  end
+
+
 end


### PR DESCRIPTION
In the the 'format' method of the mini_magick.rb file, you begin rescue a file copy operation and re-raise a custom error.  The exception class you are attempting to raise is MiniMagickError which is undefined.  I believe you meant MiniMagick::Error which is defined.

I have made this fix and have written a test to validate it.  In the test I used mocha to stub the FileUtils.copy_file method to force an exception to be raised and have added a development dependency to the gemspec for it.  Anyway, look over and pull in if you like.
