### PR TITLE
-ping should always be used with identify

### DIFF
--- a/lib/mini_magick.rb
+++ b/lib/mini_magick.rb
@@ -326,6 +326,11 @@ module MiniMagick
     end
 
     def run_command(command, *args)
+      # -ping "efficiently determine image characteristics."
+      if command == 'identify'
+        args.unshift '-ping'
+      end
+
       run(CommandBuilder.new(command, *args))
     end
 


### PR DESCRIPTION
It is implicit in newer versions, but older versions of ImageMagick will be extraordinary slow without this option.
