### PR TITLE
Allowing params on format method

### DIFF
--- a/lib/mini_magick.rb
+++ b/lib/mini_magick.rb
@@ -216,7 +216,10 @@ module MiniMagick
     # @param page [Integer] If this is an animated gif, say which 'page' you want with an integer. Leave as default if you don't care.
     # @return [nil]
     def format(format, page = 0)
-      run_command("mogrify", "-format", format, @path)
+      c = CommandBuilder.new('mogrify', '-format', format)
+      yield c if block_given?
+      c << @path
+      run(c)
 
       old_path = @path.dup
       @path.sub!(/(\.\w*)?$/, ".#{format}")


### PR DESCRIPTION
I have had cases where I needed to pass parameters together with -format to produce the desired result.  This update allows such changes to be passed in an optional block similar to the 'combine_options' method.  One example that comes to mind is to specify the pixel density while converting from pdf to jpg.
