### PR TITLE
bug fix for CommandBuilder#add

### DIFF
--- a/lib/mini_magick.rb
+++ b/lib/mini_magick.rb
@@ -394,8 +394,18 @@ module MiniMagick
         raise Error, "You must call 'format' on the image object directly!"
       elsif MOGRIFY_COMMANDS.include?(guessed_command_name)
         add(guessed_command_name, *options)
+        self
       else
         super(symbol, *args)
+      end
+    end
+
+    def +(*options)
+      push(@args.pop.gsub /^-/, '+')
+      if options.any?
+        options.each do |o|
+          push "\"#{ o }\""
+        end
       end
     end
 
@@ -412,11 +422,5 @@ module MiniMagick
       @args << arg.to_s.strip
     end
     alias :<< :push
-
-    # @deprecated Please don't use the + method its has been deprecated
-    def +(value)
-      warn "Warning: The MiniMagick::ComandBuilder#+ command has been deprecated. Please use c << '+#{value}' instead"
-      push "+#{value}"
-    end
   end
 end

--- a/test/command_builder_test.rb
+++ b/test/command_builder_test.rb
@@ -18,6 +18,12 @@ class CommandBuilderTest < Test::Unit::TestCase
     c.resize "mome fingo"
     assert_equal "-resize \"30x40\" -alpha \"1 3 4\" -resize \"mome fingo\"", c.args.join(" ")
   end
+
+  def test_plus_modifier_and_multiple_options
+    c = CommandBuilder.new("test")
+    c.distort.+ 'srt', '0.6 20'
+    assert_equal "+distort \"srt\" \"0.6 20\"", c.args.join(" ")
+  end
   
   def test_valid_command
     begin


### PR DESCRIPTION
hey folks, I'm not so sure about the rationale really for joining all the options in CommandBuilder#add. The problem I encountered with this was calling a mogrify command that uses multiple options - namely, "-distort srt" (http://www.imagemagick.org/Usage/distorts/#srt).

Would it not be possible to perhaps let specifying multiple arguments work just as you would intuitively expect it to behave - by letting those multiple arguments remain as multiple options? So I could do something like

image.combine_options do |c|
    c.distort 'srt', '0.6 20'
end
- and then expect that 'srt' and '0.6 20' will remain as multiple arguments to the '-distort' option (instead of having them compressed into 'srt 0.6 20' - which will fail)? Granted I can use '.push' right now, and have things work - but this way of getting things done isnt exactly intuitive at all, and worse, unless you read the source, you wont know about it!

For more info on my changes, pls check my commits. Thanks, and Iook forward to your comments.
