### PR TITLE
Escape output path if it contains a space

### DIFF
--- a/lib/mini_magick.rb
+++ b/lib/mini_magick.rb
@@ -338,8 +338,14 @@ module MiniMagick
 
     def run(command_builder)
       command = command_builder.command
-
+      
+      # Change LANG to C to have a consistent command output
+      saved_lang = ENV['LANG']
+      ENV['LANG'] = 'C'
       sub = Subexec.run(command, :timeout => MiniMagick.timeout)
+
+      # Restore the LANG env variable
+      ENV['LANG'] = saved_lang
 
       if sub.exitstatus != 0
         # Clean up after ourselves in case of an error

--- a/test/image_test.rb
+++ b/test/image_test.rb
@@ -229,7 +229,11 @@ class ImageTest < Test::Unit::TestCase
     result = image.composite(Image.open(TIFF_IMAGE_PATH)) do |c|
       c.gravity "center"
     end
+    # Set LANG to have a consistent output
+    saved_lang = ENV['LANG']
+    ENV['LANG'] = 'C'
     assert `diff -s #{result.path} test/composited.jpg`.include?("identical")
+    ENV['LANG'] = saved_lang
   end
 
   # http://github.com/probablycorey/mini_magick/issues#issue/8


### PR DESCRIPTION
This fixes issue #29, where the write command fails if  the output path contains a space.

I also added a small patch to make tests pass when using a non english locale :

<pre>
$ rake test
(in /home/renchap/dev/t/mini_magick)
/home/renchap/.rvm/rubies/ruby-1.8.7-p302/bin/ruby -I"lib:test" "/home/renchap/.rvm/gems/ruby-1.8.7-p302/gems/rake-0.8.7/lib/rake/rake_test_loader.rb" "test/image_test.rb" "test/command_builder_test.rb" 
Loaded suite /home/renchap/.rvm/gems/ruby-1.8.7-p302/gems/rake-0.8.7/lib/rake/rake_test_loader
Started
.....................E...F....F.
Finished in 1.03925 seconds.

  1) Error:
test_not_an_image(ImageTest):
MiniMagick::Error: Command ("identify -ping /home/renchap/dev/t/mini_magick/test/not_an_image.php") failed: {:output=>"identify: pas de d\303\251l\303\251gu\303\251 pour d\303\251coder ce format d'image `/home/renchap/dev/t/mini_magick/test/not_an_image.php' @ error/constitute.c/ReadImage/532.\n", :status_code=>1}
    /home/renchap/dev/t/mini_magick/lib/mini_magick.rb:352:in `run'
    /home/renchap/dev/t/mini_magick/lib/mini_magick.rb:334:in `run_command'
    /home/renchap/dev/t/mini_magick/lib/mini_magick.rb:146:in `valid?'
    ./test/image_test.rb:85:in `test_not_an_image'
    /home/renchap/.rvm/gems/ruby-1.8.7-p302/gems/mocha-0.9.10/lib/mocha/integration/test_unit/ruby_version_186_and_above.rb:22:in `__send__'
    /home/renchap/.rvm/gems/ruby-1.8.7-p302/gems/mocha-0.9.10/lib/mocha/integration/test_unit/ruby_version_186_and_above.rb:22:in `run'

  2) Failure:
test_simple_composite(ImageTest)
    [./test/image_test.rb:219:in `test_simple_composite'
     /home/renchap/.rvm/gems/ruby-1.8.7-p302/gems/mocha-0.9.10/lib/mocha/integration/test_unit/ruby_version_186_and_above.rb:22:in `__send__'
     /home/renchap/.rvm/gems/ruby-1.8.7-p302/gems/mocha-0.9.10/lib/mocha/integration/test_unit/ruby_version_186_and_above.rb:22:in `run']:
<false> is not true.

  3) Failure:
test_throw_on_openining_not_an_image(ImageTest)
    [./test/image_test.rb:90:in `test_throw_on_openining_not_an_image'
     /home/renchap/.rvm/gems/ruby-1.8.7-p302/gems/mocha-0.9.10/lib/mocha/integration/test_unit/ruby_version_186_and_above.rb:22:in `__send__'
     /home/renchap/.rvm/gems/ruby-1.8.7-p302/gems/mocha-0.9.10/lib/mocha/integration/test_unit/ruby_version_186_and_above.rb:22:in `run']:
<MiniMagick::Invalid> exception expected but was
Class: <MiniMagick::Error>
Message: <"Command (\"identify -ping /tmp/mini_magick20110102-13548-qcsnaz-0.php\") failed: {:output=>\"identify: pas de d\\303\\251l\\303\\251gu\\303\\251 pour d\\303\\251coder ce format d'image `/tmp/mini_magick20110102-13548-qcsnaz-0.php' @ error/constitute.c/ReadImage/532.\\n\", :status_code=>1}">
---Backtrace---
/home/renchap/dev/t/mini_magick/lib/mini_magick.rb:352:in `run'
/home/renchap/dev/t/mini_magick/lib/mini_magick.rb:334:in `run_command'
/home/renchap/dev/t/mini_magick/lib/mini_magick.rb:146:in `valid?'
/home/renchap/dev/t/mini_magick/lib/mini_magick.rb:111:in `create'
/home/renchap/dev/t/mini_magick/lib/mini_magick.rb:52:in `read'
/home/renchap/dev/t/mini_magick/lib/mini_magick.rb:83:in `open'
/home/renchap/dev/t/mini_magick/lib/mini_magick.rb:82:in `open'
./test/image_test.rb:91:in `test_throw_on_openining_not_an_image'
./test/image_test.rb:90:in `test_throw_on_openining_not_an_image'
/home/renchap/.rvm/gems/ruby-1.8.7-p302/gems/mocha-0.9.10/lib/mocha/integration/test_unit/ruby_version_186_and_above.rb:22:in `__send__'
/home/renchap/.rvm/gems/ruby-1.8.7-p302/gems/mocha-0.9.10/lib/mocha/integration/test_unit/ruby_version_186_and_above.rb:22:in `run'
---------------

32 tests, 38 assertions, 2 failures, 1 errors
rake aborted!
Command failed with status (1): [/home/renchap/.rvm/rubies/ruby-1.8.7-p302/...]

(See full trace by running task with --trace)
</pre>
