### PR TITLE
File type extension isn't always determinable from image URLs

### DIFF
--- a/lib/mini_magick.rb
+++ b/lib/mini_magick.rb
@@ -77,6 +77,7 @@ module MiniMagick
         file_or_url = file_or_url.to_s # Force it to be a String... hell or highwater
         if file_or_url.include?("://")
           require 'open-uri'
+          ext = nil unless ext and ext =~ /^\.\w{2,8}$/
           self.read(Kernel::open(file_or_url), ext)
         else
           File.open(file_or_url, "rb") do |f|

--- a/test/image_test.rb
+++ b/test/image_test.rb
@@ -57,6 +57,12 @@ class ImageTest < Test::Unit::TestCase
     image.destroy!
   end
 
+  def test_remote_image_with_complex_url
+    image = Image.open("http://a0.twimg.com/a/1296609216/images/fronts/logo_withbird_home.png?extra=foo&plus=bar")
+    image.valid?
+    image.destroy!
+  end
+
   def test_image_write
     output_path = "output.gif"
     begin


### PR DESCRIPTION
Thanks for working on this gem - it's just what I needed for my little thumbnail generator.

Image.open currently tries to extract the filetype extension from the path or URL using File.extname. This happens to work for straightforward URLs such as http://www.google.com/images/logos/logo.png, but some URLs are less well behaved; for example:
- http://www.syndetics.com/index.aspx?isbn=0300158203/SC.GIF&client=sepup&type=xw12&oclc=&upc=
- http://appserver2.static.bibliocommons.com/images/icon.book.jpg?1293461547

With these URLs, the current code results in an image temp file that's not readable. I added a simple test in my fork to check that the extension is well-behaved when the source is a URL. If it is not, the temp file is written without an extension, which does not seem to confuse ImageMagick.
