### PR TITLE
Escape paths correctly for Windows too in #write

### DIFF
--- a/lib/mini_magick.rb
+++ b/lib/mini_magick.rb
@@ -135,7 +135,7 @@ module MiniMagick
     end
     
     def escaped_path
-      "\"#{Pathname.new(@path).to_s}\""
+      Pathname.new(@path).to_s.inspect
     end
 
     # Checks to make sure that MiniMagick can read the file and understand it.
@@ -259,9 +259,7 @@ module MiniMagick
     def write(output_to)
       if output_to.kind_of?(String) || !output_to.respond_to?(:write)
         FileUtils.copy_file @path, output_to
-        # We need to escape the output path if it contains a space
-        escaped_output_to = output_to.to_s.gsub(' ', '\\ ')
-        run_command "identify", escaped_output_to # Verify that we have a good image
+        run_command "identify", output_to.to_s.inspect # Verify that we have a good image
       else # stream
         File.open(@path, "rb") do |f|
           f.binmode


### PR DESCRIPTION
The issue #29 is still happening on Windows platform when output path has spaces in it. This pull request fixes it by using String#inspect to quote the whole path.
