### PR TITLE
added support for internal image creation operators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /pkg
 coverage
 .yardoc
+.rvmrc

--- a/README.rdoc
+++ b/README.rdoc
@@ -83,6 +83,13 @@ Want to get some meta-information out?
   image["EXIF:BitsPerSample"] # It also can get all the EXIF tags
   image["%m:%f %wx%h"]        # Or you can use one of the many options of the format command
 
+Want to use an internal image creation to create a big black square?
+
+  image = MiniMagick::Image.create 'jpg', false do |c|
+    c.size '1024x1024' # creates image option '-size 1024x1024'
+    c.canvas 'black'   # creates image creation operator 'canvas:black'
+  end
+
 For more on the format command see
 http://www.imagemagick.org/script/command-line-options.php#format
 

--- a/lib/mini_magick.rb
+++ b/lib/mini_magick.rb
@@ -24,6 +24,8 @@ module MiniMagick
 
   MOGRIFY_COMMANDS = %w{adaptive-blur adaptive-resize adaptive-sharpen adjoin affine alpha annotate antialias append authenticate auto-gamma auto-level auto-orient background bench iterations bias black-threshold blue-primary point blue-shift factor blur border bordercolor brightness-contrast caption string cdl filename channel type charcoal radius chop clip clamp clip-mask filename clip-path id clone index clut contrast-stretch coalesce colorize color-matrix colors colorspace type combine comment string compose operator composite compress type contrast convolve coefficients crop cycle amount decipher filename debug events define format:option deconstruct delay delete index density depth despeckle direction type display server dispose method distort type coefficients dither method draw string edge radius emboss radius encipher filename encoding type endian type enhance equalize evaluate operator evaluate-sequence operator extent extract family name fft fill filter type flatten flip floodfill flop font name format string frame function name fuzz distance fx expression gamma gaussian-blur geometry gravity type green-primary point help identify ifft implode amount insert index intent type interlace type interline-spacing interpolate method interword-spacing kerning label string lat layers method level limit type linear-stretch liquid-rescale log format loop iterations mask filename mattecolor median radius modulate monitor monochrome morph morphology method kernel motion-blur negate noise radius normalize opaque ordered-dither NxN orient type page paint radius ping pointsize polaroid angle posterize levels precision preview type print string process image-filter profile filename quality quantize quiet radial-blur angle raise random-threshold low,high red-primary point regard-warnings region remap filename render repage resample resize respect-parentheses roll rotate degrees sample sampling-factor scale scene seed segments selective-blur separate sepia-tone threshold set attribute shade degrees shadow sharpen shave shear sigmoidal-contrast size sketch solarize threshold splice spread radius strip stroke strokewidth stretch type style type swap indexes swirl degrees texture filename threshold thumbnail tile filename tile-offset tint transform transparent transparent-color transpose transverse treedepth trim type type undercolor unique-colors units type unsharp verbose version view vignette virtual-pixel method wave weight type white-point point white-threshold write filename}
 
+  IMAGE_CREATION_OPERATORS = %w{canvas caption gradient label logo pattern plasma radial radient rose text tile xc }
+
   class Error < RuntimeError; end
   class Invalid < StandardError; end
 
@@ -436,7 +438,10 @@ module MiniMagick
       if guessed_command_name == "format"
         raise Error, "You must call 'format' on the image object directly!"
       elsif MOGRIFY_COMMANDS.include?(guessed_command_name)
-        add(guessed_command_name, *options)
+        add_command(guessed_command_name, *options)
+        self
+      elsif IMAGE_CREATION_OPERATORS.include?(guessed_command_name)
+        add_creation_operator(guessed_command_name, *options)
         self
       else
         super(symbol, *args)
@@ -452,13 +457,23 @@ module MiniMagick
       end
     end
 
-    def add(command, *options)
+    def add_command(command, *options)
       push "-#{command}"
       if options.any?
         options.each do |o|
           push "\"#{ o }\""
         end
       end
+    end
+
+    def add_creation_operator(command, *options)
+      creation_command = command
+      if options.any?
+        options.each do |option|
+          creation_command << ":#{option}"
+        end
+      end
+      push creation_command
     end
 
     def push(arg)

--- a/test/command_builder_test.rb
+++ b/test/command_builder_test.rb
@@ -40,4 +40,10 @@ class CommandBuilderTest < Test::Unit::TestCase
     c.auto_orient
     assert_equal "-auto-orient", c.args.join(" ")
   end
+  
+  def test_canvas
+    c = CommandBuilder.new('test')
+    c.canvas 'black'
+    assert_equal "canvas:black", c.args.join
+  end
 end


### PR DESCRIPTION
lib/mini_magick.rb: changed add() to add_command(); added
add_creation_operator(); Added IMAGE_CREATION_OPERATORS list taken from
ImageMagick Examples doc.
test/command_builder_test.rb: added test for add_creation_operator().
README.rdoc - added minimal note with demo code
