### PR TITLE
Tool param for combine_options method

### DIFF
--- a/lib/mini_magick.rb
+++ b/lib/mini_magick.rb
@@ -335,6 +335,8 @@ module MiniMagick
     # @yieldparam command [CommandBuilder]
     def combine_options(tool, &block)
       c = CommandBuilder.new(tool || :mogrify)
+
+      c << @path if tool == :convert
       block.call(c)
       c << @path
       run(c)


### PR DESCRIPTION
When using mini_magick i happen to run into a problem with no chance of choose tool in combine_options method. For me mogrify command doesn't support some of options, instead i'm using convert.
