### PR TITLE
"tool" argument in "combine_options" method should have a default value

### DIFF
--- a/lib/mini_magick.rb
+++ b/lib/mini_magick.rb
@@ -335,8 +335,8 @@ module MiniMagick
     #   end
     #
     # @yieldparam command [CommandBuilder]
-    def combine_options(tool, &block)
-      c = CommandBuilder.new(tool || :mogrify)
+    def combine_options(tool = :mogrify, &block)
+      c = CommandBuilder.new(tool)
 
       c << @path if tool == :convert
       block.call(c)


### PR DESCRIPTION
```
ArgumentError: wrong number of arguments (0 for 1)
    /Users/dumitru/Dropbox/code/gems/mini_magick/lib/mini_magick.rb:323:in `combine_options'
```

``` ruby
# was throwing the above error
image.combine_options do |c|
end
```
