### PR TITLE
Update lib/mini_magick.rb

### DIFF
--- a/lib/mini_magick.rb
+++ b/lib/mini_magick.rb
@@ -487,7 +487,7 @@ module MiniMagick
     end
     
     def escape_string(value)
-      '"' + value + '"'
+      '"' + value.to_s + '"'
     end
 
     def add_creation_operator(command, *options)


### PR DESCRIPTION
Causing problems with Ruby 1.9.3 when FixedNum is passed as an argument. .to_s fixes the issue.
