### PR TITLE
Striping whitespaces can lead to argument concatenation

### DIFF
--- a/lib/mini_magick.rb
+++ b/lib/mini_magick.rb
@@ -451,7 +451,7 @@ module MiniMagick
     end
 
     def command
-      "#{MiniMagick.processor} #{@command} #{@args.join(' ')}".strip
+      "#{MiniMagick.processor} #{@command} #{@args.join(' ')}"
     end
 
     def method_missing(symbol, *options)
@@ -502,7 +502,7 @@ module MiniMagick
     end
 
     def push(arg)
-      @args << arg.to_s.strip
+      @args << arg.to_s
     end
     alias :<< :push
   end


### PR DESCRIPTION
Example:

If we annotate the value `text` (note the padding space) and escape it (`text\`) and then strip it, it results in the following command:

`mogrify -annotate text\ /output/file.png`

which is then parsed (by imagemagick) as:

`["-annotate", "text /output/file.png"]`

when it should be:

`["-annotate", "text ", "/output/file.png"]`

or equivalently (again, notice the double spacing after the backslash):

`mogrify -annotate text\  /output/file.png`
