### PR TITLE
Restore compatibility with GraphicsMagick.

### DIFF
--- a/lib/mini_magick.rb
+++ b/lib/mini_magick.rb
@@ -21,15 +21,15 @@ module MiniMagick
         self.processor = "gm"
       end
     end
-    
+
     def image_magick_version
       @@version ||= Gem::Version.create(`mogrify --version`.split(" ")[2].split("-").first)
     end
-    
+
     def minimum_image_magick_version
       @@minimum_version ||= Gem::Version.create("6.6.3")
     end
-    
+
     def valid_version_installed?
       image_magick_version >= minimum_image_magick_version
     end
@@ -395,6 +395,11 @@ module MiniMagick
       # -ping "efficiently determine image characteristics."
       if command == 'identify'
         args.unshift '-ping'
+
+        # GraphicsMagick's identify has no -quiet option
+        if MiniMagick.processor.to_s == 'gm'
+          args.delete('-quiet')
+        end
       end
 
       run(CommandBuilder.new(command, *args))
@@ -486,7 +491,7 @@ module MiniMagick
         end
       end
     end
-    
+
     def escape_string(value)
       Shellwords.escape(value.to_s)
     end


### PR DESCRIPTION
Commit 302aaa3b added the -quiet option on
identify commands. This broke compatibility with
GraphicsMagick as there is no such option for
their implementation identify. It may make more
sense to put in the mini_gmagick file but here's
the quick fix.

This is a squashed version of pull request #66. I created a different branch/pull-request as others may be using the current one via bundler so it wouldn't  be smart to mess with the history.
