### PR TITLE
Update available mogrify commands

### DIFF
--- a/lib/mini_magick.rb
+++ b/lib/mini_magick.rb
@@ -35,7 +35,7 @@ module MiniMagick
     end
   end
 
-  MOGRIFY_COMMANDS = %w{adaptive-blur adaptive-resize adaptive-sharpen adjoin affine alpha annotate antialias append authenticate auto-gamma auto-level auto-orient background bench iterations bias black-threshold blue-primary blue-shift blur border bordercolor brightness-contrast caption cdl channel charcoal chop clip clamp clip-mask clip-path clone clut contrast-stretch coalesce colorize color-matrix colors colorspace combine comment compose composite compress contrast convolve coefficients crop cycle decipher debug define deconstruct delay delete density depth despeckle direction dissolve display dispose distort dither draw edge emboss encipher encoding endian enhance equalize evaluate evaluate-sequence extent extract family fft fill filter flatten flip floodfill flop font format frame function fuzz fx gamma gaussian-blur geometry gravity green-primary help identify ifft implode insert index intent interlace interline-spacing interpolate interword-spacing kerning label lat layers level limit linear-stretch liquid-rescale log loop mask mattecolor median modulate monitor monochrome morph morphology motion-blur negate noise normalize opaque ordered-dither orient page paint ping pointsize polaroid posterize precision preview print process profile quality quantize quiet radial-blur raise random-threshold red-primary regard-warnings region remap render repage resample resize respect-parentheses roll rotate sample sampling-factor scale scene seed segments selective-blur separate sepia-tone set shade shadow sharpen shave shear sigmoidal-contrast size sketch solarize splice spread strip stroke strokewidth stretch style swap swirl texture threshold thumbnail tile tile-offset tint transform transparent transparent-color transpose transverse treedepth trim type undercolor unique-colors units unsharp verbose version view vignette virtual-pixel wave weight white-point white-threshold write}
+  MOGRIFY_COMMANDS = %w{adaptive-blur adaptive-resize adaptive-sharpen adjoin affine alpha annotate antialias append attenuate authenticate auto-gamma auto-level auto-orient backdrop background bench bias black-point-compensation black-threshold blend blue-primary blue-shift blur border bordercolor borderwidth brightness-contrast cache caption cdl channel charcoal chop clamp clip clip-mask clip-path clone clut coalesce colorize colormap color-matrix colors colorspace combine comment compose composite compress contrast contrast-stretch convolve crop cycle debug decipher deconstruct define delay delete density depth descend deskew despeckle direction displace display dispose dissimilarity-threshold dissolve distort dither draw duplicate edge emboss encipher encoding endian enhance equalize evaluate evaluate-sequence extent extract family features fft fill filter flatten flip floodfill flop font foreground format frame function fuzz fx gamma gaussian-blur geometry gravity green-primary hald-clut help highlight-color iconGeometry iconic identify ift immutable implode insert intent interlace interpolate interline-spacing interword-spacing kerning label lat layers level level-colors limit linear-stretch linewidth liquid-rescale list log loop lowlight-color magnify map mask mattecolor median metric mode modulate monitor monochrome morph morphology mosaic motion-blur name negate noise normalize opaque ordered-dither orient page paint path pause pen perceptible ping pointsize polaroid poly posterize precision preview print process profile quality quantize quiet radial-blur raise random-threshold red-primary regard-warnings region remap remote render repage resample resize respect-parentheses reverse roll rotate sample sampling-factor scale scene screen seed segment selective-blur separate sepia-tone set shade shadow shared-memory sharpen shave shear sigmoidal-contrast silent size sketch smush snaps solarize sparse-color splice spread statistic stegano stereo stretch strip stroke strokewidth style subimage-search swap swirl synchronize taint text-font texture threshold thumbnail tile tile-offset tint title transform transparent transparent-color transpose transverse treedepth trim type undercolor unique-colors units unsharp update verbose version view vignette virtual-pixel visual watermark wave weight white-point white-threshold window window-group write}
 
   IMAGE_CREATION_OPERATORS = %w{canvas caption gradient label logo pattern plasma radial radient rose text tile xc }
 
@@ -354,10 +354,10 @@ module MiniMagick
     #   end
     #
     # @yieldparam command [CommandBuilder]
-    def combine_options(tool = :mogrify, &block)
+    def combine_options(tool = "mogrify", &block)
       c = CommandBuilder.new(tool)
 
-      c << @path if tool == :convert
+      c << @path if tool.to_s == "convert"
       block.call(c)
       c << @path
       run(c)
@@ -442,17 +442,16 @@ module MiniMagick
   end
 
   class CommandBuilder
-    attr :args
-    attr :command
+    attr_reader :args
 
-    def initialize(command, *options)
-      @command = command
+    def initialize(tool, *options)
+      @tool = tool
       @args = []
       options.each { |arg| push(arg) }
     end
 
     def command
-      "#{MiniMagick.processor} #{@command} #{@args.join(' ')}".strip
+      "#{MiniMagick.processor} #{@tool} #{@args.join(' ')}".strip
     end
 
     def method_missing(symbol, *options)

--- a/test/command_builder_test.rb
+++ b/test/command_builder_test.rb
@@ -9,6 +9,12 @@ class CommandBuilderTest < Test::Unit::TestCase
     assert_equal '-resize 30x40', c.args.join(" ")
   end
 
+  def test_full_command
+    c = CommandBuilder.new("test")
+    c.resize "30x40"
+    assert_equal "test -resize 30x40", c.command
+  end
+
   def test_complicated
     c = CommandBuilder.new("test")
     c.resize "30x40"
@@ -22,7 +28,7 @@ class CommandBuilderTest < Test::Unit::TestCase
     c.distort.+ 'srt', '0.6 20'
     assert_equal '+distort srt 0.6\ 20', c.args.join(" ")
   end
-  
+
   def test_valid_command
     begin
       c = CommandBuilder.new("test", "path")
@@ -38,7 +44,7 @@ class CommandBuilderTest < Test::Unit::TestCase
     c.auto_orient
     assert_equal "-auto-orient", c.args.join(" ")
   end
-  
+
   def test_canvas
     c = CommandBuilder.new('test')
     c.canvas 'black'


### PR DESCRIPTION
Trying to use the "attenuate" command, I noticed the command list is not up-to-date and pulled the latest from ImageMagick.

Also, make the wording consistent for the "tool" used when building a command with the CommandBuilder.
