### PR TITLE
Remove method_missing in favor of define_method

### DIFF
--- a/test/command_builder_test.rb
+++ b/test/command_builder_test.rb
@@ -45,9 +45,22 @@ class CommandBuilderTest < Test::Unit::TestCase
     assert_equal "-auto-orient", c.args.join(" ")
   end
 
+  def test_dashed_via_send
+    c = CommandBuilder.new("test")
+    c.send("auto-orient")
+    assert_equal "-auto-orient", c.args.join(" ")
+  end
+
   def test_canvas
     c = CommandBuilder.new('test')
     c.canvas 'black'
     assert_equal "canvas:black", c.args.join
   end
+
+  def test_set
+    c = CommandBuilder.new("test")
+    c.set "colorspace RGB"
+    assert_equal 'test -set colorspace\ RGB', c.command
+  end
+
 end


### PR DESCRIPTION
Ran into an issue where I tried using the `set` ImageMagick command, but because of a gem being required (Sinatra) in the app, `set` is defined somewhere else in the chain, so it gets called before `method_missing`.

I've removed `method_missing` in favor of `define_method` for the CommandBuilder, so all ImageMagick commands are available in the class without a need to worry that they will be overridden by another library.
