### PR TITLE
Made the test-suite green by fixing the colorspace

### DIFF
--- a/lib/mini_magick.rb
+++ b/lib/mini_magick.rb
@@ -222,7 +222,7 @@ module MiniMagick
       # Why do I go to the trouble of putting in newlines? Because otherwise animated gifs screw everything up
       case value.to_s
       when "colorspace"
-        run_command("identify", "-format", format_option("%r"), escaped_path).split("\n")[0]
+        run_command("identify", "-format", format_option("%r"), escaped_path).split("\n")[0].strip
       when "format"
         run_command("identify", "-format", format_option("%m"), escaped_path).split("\n")[0]
       when "height"

--- a/test/image_test.rb
+++ b/test/image_test.rb
@@ -125,7 +125,7 @@ class ImageTest < Test::Unit::TestCase
     assert_equal 150, image[:width]
     assert_equal 55, image[:height]
     assert_equal [150, 55], image[:dimensions]
-    assert_equal 'PseudoClassRGB', image[:colorspace]
+    assert_equal 'PseudoClass sRGB', image[:colorspace]
     assert_match(/^gif$/i, image[:format])
     image.destroy!
   end


### PR DESCRIPTION
Hi,

I just made the testsuite green. The issue is that ImageMagick apparently assumes that all images is of the colorspace of sRGB. I found this in the documentation:

> The first major change was to swap -colorspace RGB and -colorspace sRGB. In earlier versions, RGB really meant non-linear sRGB. With the completion of the changes, RGB now means linear color and sRGB means non-linear color in terms of their respective colorspaces.
> 
> ImageMagick supports color profiles, however, for images without a profile or a declaration of colorspace, ImageMagick assumes non-linear sRGB. Most image processing algorithms assume a linear colorspace, therefore it might be prudent to convert to linear color or remove the gamma function before certain image processing algorithms are applied. For example,
> 
> Afterwards, the verbose information for the output file lists the colorspace as RGB. **This only works on image types containing meta data that distinguishes between linear RGB and non-linear sRGB, such as PNG and GIF. Therefore, if the above command is run with a JPG or TIF output format, the verbose information for the colorspace still shows sRGB.** In order to properly have the JPG output know that it is linear RGB, include an appropriate color profile.

http://www.imagemagick.org/script/color-management.php

Afterwards I saw an error where

``` ruby
image[:colorspace] # would return 'PseudoClass sRGB ' (space in the end)
```

So I stripped the output from the command-calling.
