### PR TITLE
Update Readme to inform the ruby 1.9.2-p180 problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,7 @@ And you are sorted.
 # Requirements
 
 You must have ImageMagick or GraphicsMagick installed.
+
+# Caveats
+
+Version 3.5 doesn't work in Ruby 1.9.2-p180. If you are running this Ruby version use the 3.4 version of this gem.


### PR DESCRIPTION
I hope this message saves hours to people that ran into the same situation as I did. MiniMagick is not working in 180 patchlevel of ruby 1.9.2, and the only fix is to downgrade to 0.4. 
