### PR TITLE
Add the option to specify the path where imagemagic (or other processors) is installed

### DIFF
--- a/lib/mini_magick.rb
+++ b/lib/mini_magick.rb
@@ -7,6 +7,7 @@ require 'shellwords'
 module MiniMagick
   class << self
     attr_accessor :processor
+    attr_accessor :processor_path
     attr_accessor :timeout
 
 
@@ -20,6 +21,10 @@ module MiniMagick
       elsif `type -P gm`.size > 0
         self.processor = "gm"
       end
+    end
+
+    def windows?
+      RUBY_PLATFORM =~ /mswin|mingw|cygwin/
     end
 
     def image_magick_version
@@ -368,7 +373,7 @@ module MiniMagick
 
     # Check to see if we are running on win32 -- we need to escape things differently
     def windows?
-      RUBY_PLATFORM =~ /mswin|mingw|cygwin/
+      MiniMagick.windows?
     end
 
     def composite(other_image, output_extension = 'jpg', &block)
@@ -454,7 +459,14 @@ module MiniMagick
     end
 
     def command
-      "#{MiniMagick.processor} #{@tool} #{@args.join(' ')}".strip
+      com = "#{@tool} #{@args.join(' ')}".strip
+      com = "#{MiniMagick.processor} #{com}" unless MiniMagick.processor.nil?
+
+      unless MiniMagick.processor_path.nil?
+        seperator = MiniMagick.windows? ? "\\" : "/"
+        com = "#{MiniMagick.processor_path}#{seperator}#{com}"
+      end
+      com.strip
     end
 
     # Add each mogrify command in both underscore and dash format

--- a/test/command_builder_test.rb
+++ b/test/command_builder_test.rb
@@ -3,6 +3,16 @@ require 'test_helper'
 class CommandBuilderTest < Test::Unit::TestCase
   include MiniMagick
 
+  def setup
+    @processor_path = MiniMagick.processor_path
+    @processor = MiniMagick.processor
+  end
+
+  def teardown
+    MiniMagick.processor_path = @processor_path
+    MiniMagick.processor = @processor
+  end
+
   def test_basic
     c = CommandBuilder.new("test")
     c.resize "30x40"
@@ -63,4 +73,18 @@ class CommandBuilderTest < Test::Unit::TestCase
     assert_equal 'test -set colorspace\ RGB', c.command
   end
 
+  def test_processor_path
+    MiniMagick.processor_path = "/a/strange/path"
+    c = CommandBuilder.new('test')
+    c.auto_orient
+    assert_equal c.command, "/a/strange/path/test -auto-orient"
+  end
+
+  def test_processor_path_with_processor
+    MiniMagick.processor_path = "/a/strange/path"
+    MiniMagick.processor = "processor"
+    c = CommandBuilder.new('test')
+    c.auto_orient
+    assert_equal c.command, "/a/strange/path/processor test -auto-orient"
+  end
 end


### PR DESCRIPTION
I added this because I run in a  server where the imagemagic commands are not in the path and I would like to use the full path of the executables.
