### PR TITLE
Reversed logic in choose_processor-method so we use GraphicsMagick if available

### DIFF
--- a/lib/mini_magick.rb
+++ b/lib/mini_magick.rb
@@ -16,10 +16,10 @@ module MiniMagick
     #
     # TODO: Write tests for this and figure out what platforms it supports
     def choose_processor
-      if `type -P mogrify`.size > 0
+      if `type -P gm`.size > 0
+        self.processor = 'gm'
+      elsif `type -P mogrify`.size > 0
         return
-      elsif `type -P gm`.size > 0
-        self.processor = "gm"
       end
     end
 


### PR DESCRIPTION
I couldn't understand why the old code preferred not using GraphicsMagick, even though it was available.

I reversed the logic so GM is used if available, any thoughts on this?
