### PR TITLE
[RFC] Add strict mode for secure command execution

### DIFF
--- a/lib/mini_magick.rb
+++ b/lib/mini_magick.rb
@@ -9,6 +9,7 @@ module MiniMagick
     attr_accessor :processor
     attr_accessor :processor_path
     attr_accessor :timeout
+    attr_accessor :strict_mode
 
 
     # Experimental method for automatically selecting a processor
@@ -42,6 +43,7 @@ module MiniMagick
 
   class Error < RuntimeError; end
   class Invalid < StandardError; end
+  class StrictModeError < Error; end
 
   class Image
     # @return [String] The location of the current working file
@@ -433,17 +435,13 @@ module MiniMagick
 
   class CommandBuilder
     def initialize(tool, *options)
-      @tool = tool
+      @tool = Tool.new tool
       @args = []
       options.each { |arg| push(arg) }
     end
 
     def command
-      com = "#{@tool} #{args.join(' ')}".strip
-      com = "#{MiniMagick.processor} #{com}" unless MiniMagick.processor.nil?
-
-      com = File.join MiniMagick.processor_path, com unless MiniMagick.processor_path.nil?
-      com.strip
+      [@tool.path, *args].join ' '
     end
 
     def args
@@ -514,5 +512,34 @@ module MiniMagick
       @args << arg.to_s.strip
     end
     alias :<< :push
+  end
+
+  class Tool
+    TOOLS = %w{convert composite identify mogrify}.freeze
+    PROCESSORS = [nil, "gm"]
+
+    def initialize(tool, options = {})
+      @tool = tool
+      @processor = options.fetch(:processor, MiniMagick.processor)
+      @processor_path = options.fetch(:processor_path, MiniMagick.processor_path)
+      strict_mode = options.fetch(:strict_mode, MiniMagick.strict_mode)
+
+      validate_args if strict_mode
+    end
+
+    def path
+      File.join [@processor_path, binary].compact
+    end
+
+    private
+      def validate_args
+        raise StrictModeError, "'#@tool' is not in the list of allowed tools: #{TOOLS.join ', '}" unless TOOLS.include? @tool
+        raise StrictModeError, "processor must be either nil or 'gm'" unless PROCESSORS.include? @processor
+        raise StrictModeError, "'#@processor_path' is not a valid directory" unless @processor_path.nil? || File.directory?(@processor_path)
+      end
+
+      def binary
+        "#@processor #@tool".strip
+      end
   end
 end

--- a/test/command_builder_test.rb
+++ b/test/command_builder_test.rb
@@ -6,11 +6,13 @@ class CommandBuilderTest < Test::Unit::TestCase
   def setup
     @processor_path = MiniMagick.processor_path
     @processor = MiniMagick.processor
+    @strict_mode = MiniMagick.strict_mode
   end
 
   def teardown
     MiniMagick.processor_path = @processor_path
     MiniMagick.processor = @processor
+    MiniMagick.strict_mode = @strict_mode
   end
 
   def test_basic
@@ -86,5 +88,48 @@ class CommandBuilderTest < Test::Unit::TestCase
     c = CommandBuilder.new('test')
     c.auto_orient
     assert_equal c.command, "/a/strange/path/processor test -auto-orient"
+  end
+
+  def test_valid_processor_path_in_strict_mode
+    MiniMagick.strict_mode = true
+    MiniMagick.processor_path = "test"
+    c = CommandBuilder.new('identify')
+    assert_equal c.command, "test/identify"
+  end
+
+  def test_invalid_processor_path_in_strict_mode
+    MiniMagick.strict_mode = true
+    MiniMagick.processor_path = "/a/stange/path"
+    assert_raise MiniMagick::StrictModeError, "'/a/strange/path' is not a valid directory" do
+      CommandBuilder.new('identify')
+    end
+  end
+
+  def test_valid_processor_in_strict_mode
+    MiniMagick.strict_mode = true
+    MiniMagick.processor = "gm"
+    c = CommandBuilder.new('identify')
+    assert_equal c.command, "gm identify"
+  end
+
+  def test_invalid_processor_in_strict_mode
+    MiniMagick.strict_mode = true
+    MiniMagick.processor = "test"
+    assert_raise MiniMagick::StrictModeError, "processor must be either nil or 'gm'" do
+      CommandBuilder.new('identify')
+    end
+  end
+
+  def test_valid_tool_in_strict_mode
+    MiniMagick.strict_mode = true
+    c = CommandBuilder.new('identify')
+    assert_equal c.command, "identify"
+  end
+
+  def test_invalid_tool_in_strict_mode
+    MiniMagick.strict_mode = true
+    assert_raise MiniMagick::StrictModeError, "'test' is not in the list of allowed tools: convert, composite, identify, mogrify" do
+      CommandBuilder.new('test')
+    end
   end
 end


### PR DESCRIPTION
This adds a new setting `MiniMagick.strict_mode` that enables some
sanity checks for `CommandBuilder` execution.

I did this because I'm afraid that passing some bad parameters to `CommandBuilder` could lead to arbitrary shell execution and I don't think the default flexibility of `CommandBuilder` is needed given its context.

Then again I'm not sure that strict mode fits all use cases, so I left it disabled by default.

I also should probably move some of the tests into a `ToolTest` suite, because that's where they belong.
