### PR TITLE
temporary files directory configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,22 @@ end
 result.write "output.jpg"
 ```
 
+## Configuration
+
+By default all temporary files are written to the temporary directory of the system `Dir.tmpdir`. If your application does not have permissions to write there, you may choose another directory:
+
+```ruby
+MiniMagick::Image.setup do |config|
+  config.tmpdir = Rails.root.join('tmp', 'uploads').to_s
+end
+```
+
+If you're using Rails, create an initializer for this:
+
+```ruby
+config/initializers/mini_magick.rb
+```
+
 ## Thinking of switching from RMagick?
 
 Unlike [RMagick](http://rmagick.rubyforge.org), MiniMagick is a much thinner wrapper around ImageMagick.

--- a/lib/mini_magick.rb
+++ b/lib/mini_magick.rb
@@ -5,6 +5,7 @@ require 'pathname'
 require 'shellwords'
 
 module MiniMagick
+
   class << self
     attr_accessor :processor
     attr_accessor :processor_path
@@ -46,6 +47,13 @@ module MiniMagick
   class Image
     # @return [String] The location of the current working file
     attr_accessor :path
+
+    @@tmpdir = Dir.tmpdir
+    mattr_accessor :tmpdir
+
+    def self.setup
+      yield self
+    end
 
     # Class Methods
     # -------------
@@ -159,7 +167,7 @@ module MiniMagick
       # @return [Image] The created image
       def create(ext = nil, validate = true, &block)
         begin
-          tempfile = Tempfile.new(['mini_magick', ext.to_s.downcase])
+          tempfile = Tempfile.new(['mini_magick', ext.to_s.downcase], @@tmpdir)
           tempfile.binmode
           block.call(tempfile)
           tempfile.close
@@ -367,7 +375,7 @@ module MiniMagick
 
     def composite(other_image, output_extension = 'jpg', &block)
       begin
-        second_tempfile = Tempfile.new(output_extension)
+        second_tempfile = Tempfile.new(output_extension, @@tmpdir)
         second_tempfile.binmode
       ensure
         second_tempfile.close


### PR DESCRIPTION
One may not have permissions to write temporary files to Dir.tmpdir as enforced by mini_magick, this is intended to solve this problem.
