### PR TITLE
EXIF: Switch to #chomp, #chop was cutting off last char

### DIFF
--- a/lib/mini_magick.rb
+++ b/lib/mini_magick.rb
@@ -238,7 +238,7 @@ module MiniMagick
         # Get the EXIF original capture as a Time object
         Time.local(*self["EXIF:DateTimeOriginal"].split(/:|\s+/)) rescue nil
       when /^EXIF\:/i
-        result = run_command('identify', '-format', "%[#{value}]", path).chop
+        result = run_command('identify', '-format', "%[#{value}]", path).chomp
         if result.include?(",")
           read_character_data(result)
         else


### PR DESCRIPTION
Tests were failing for me due to the last character of EXIF data being cut of by `#chop`. Using `#chomp` fixes this.

This is on:

Version: ImageMagick 6.8.7-0 2013-10-01 Q16 http://www.imagemagick.org
Copyright: Copyright (C) 1999-2013 ImageMagick Studio LLC
Features: DPC
Delegates: bzlib freetype jng jp2 jpeg lcms ltdl png png tiff xml zlib

and

ruby 2.0.0p247 (2013-06-27 revision 41674) [x86_64-darwin12.4.0]
