### PR TITLE
Consider Pathname object as String, rather than stream when MiniMagick::Image#write

### DIFF
--- a/lib/mini_magick/image.rb
+++ b/lib/mini_magick/image.rb
@@ -280,7 +280,7 @@ module MiniMagick
     # @return [IOStream, Boolean] If you pass in a file location [String] then you get a success boolean. If its a stream, you get it back.
     # Writes the temporary image that we are using for processing to the output path
     def write(output_to)
-      if output_to.kind_of?(String) || !output_to.respond_to?(:write)
+      if output_to.kind_of?(String) || output_to.kind_of?(Pathname) || !output_to.respond_to?(:write)
         FileUtils.copy_file path, output_to
         run_command "identify", MiniMagick::Utilities.windows? ? path_for_windows_quote_space(output_to.to_s) :  output_to.to_s # Verify that we have a good image
       else # stream


### PR DESCRIPTION
When `MiniMagick::Image#write` to a `Pathname` object such as `Rails.root.join('image/sample.jpg')`,  an `Encoding::UndefinedConversionError ("\x89" from ASCII-8BIT to UTF-8)` error occurs. The mini_magick takes a Pathname object as stream, which also respond_to :write but not act as expected. And passing a Pathname object to `MiniMagick::Image#write` method is reasonable.
