### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Tested on the following Rubies: MRI 1.8.7, 1.9.2, 1.9.3, 2.0.0, REE, JRuby, Rubi
 
 [![Build Status](https://secure.travis-ci.org/minimagick/minimagick.png)](http://travis-ci.org/minimagick/minimagick)
 [![Code Climate](https://codeclimate.com/github/minimagick/minimagick.png)](https://codeclimate.com/github/minimagick/minimagick)
+[![Inline docs](http://inch-pages.github.io/github/minimagick/minimagick.png)](http://inch-pages.github.io/github/minimagick/minimagick)
 
 ## Installation
 


### PR DESCRIPTION
Hi there,

this patch adds a docs badge to the README to show off inline-documentation to the casual visitor: [![Inline docs](http://inch-pages.github.io/github/minimagick/minimagick.png)](http://inch-pages.github.io/github/minimagick/minimagick)

The badge links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of documentation in Ruby projects. The status page for MiniMagick is http://inch-pages.github.io/github/minimagick/minimagick/

Inch Pages is still in it's infancy, but already used by projects like [Guard](https://github.com/guard/guard), [Haml](https://github.com/haml/haml), [Pry](https://github.com/pry/pry), and [Libnotify](https://github.com/splattael/libnotify).

What do you think?
