### PR TITLE
Add spec that we get a reasonable error message when ImageMagick is not found

### DIFF
--- a/spec/lib/mini_magick/image_spec.rb
+++ b/spec/lib/mini_magick/image_spec.rb
@@ -21,7 +21,7 @@ describe MiniMagick::Image do
       begin
         MiniMagick::Image.open(SIMPLE_IMAGE_PATH)
       rescue Exception => e
-        e.message.should match(/No such file/)
+        e.message.should match(/(No such file|not found)/)
       end
     end
   end


### PR DESCRIPTION
As the commit message says, this is an issue with v3.7.0 that was (accidentally?) fixed in commit 2f6f7a1, and I would like it to stay fixed.  The previous error message was "undefined method `size' for nil:NilClass", which is not very helpful, while the current one says "No such file or directory - identify".

The weird error message was a problem for me on a server for a few days until I realized that my PATH was set incorrectly.
