### PR TITLE
Add MiniMagick.validate_on_create and MiniMagick.validate_on_write flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ MiniMagick.processor = :gm
 
 And you are sorted.
 
+## Optional image validation
+
+By default, MiniMagick validates image each time it's opening or writing it. Validation means executing `identify -quiet -ping` command on target image. This adds additional overhead to the whole processing. Sometimes it's safe to assume that all input and output images are valid by default and turn off validation:
+
+```ruby
+MiniMagick.validate_on_create = false
+MiniMagick.validate_on_write = false
+```
+
 # Requirements
 
 You must have ImageMagick or GraphicsMagick installed.

--- a/lib/mini_magick.rb
+++ b/lib/mini_magick.rb
@@ -9,10 +9,15 @@ require 'mini_magick/image'
 require 'mini_magick/utilities'
 
 module MiniMagick
+  @validate_on_create = true
+  @validate_on_write = true
+
   class << self
     attr_accessor :processor
     attr_accessor :processor_path
     attr_accessor :timeout
+    attr_accessor :validate_on_create
+    attr_accessor :validate_on_write
 
     ##
     # Tries to detect the current processor based if any of the processors exist.

--- a/lib/mini_magick/image.rb
+++ b/lib/mini_magick/image.rb
@@ -128,7 +128,7 @@ module MiniMagick
       # @param validate [Boolean] If false, skips validation of the created image. Defaults to true.
       # @yield [IOStream] You can #write bits to this object to create the new Image
       # @return [Image] The created image
-      def create(ext = nil, validate = true, &block)
+      def create(ext = nil, validate = MiniMagick.validate_on_create, &block)
         begin
           tempfile = Tempfile.new(['mini_magick', ext.to_s.downcase])
           tempfile.binmode
@@ -282,7 +282,9 @@ module MiniMagick
     def write(output_to)
       if output_to.kind_of?(String) || output_to.kind_of?(Pathname) || !output_to.respond_to?(:write)
         FileUtils.copy_file path, output_to
-        run_command "identify", MiniMagick::Utilities.windows? ? path_for_windows_quote_space(output_to.to_s) :  output_to.to_s # Verify that we have a good image
+        if MiniMagick.validate_on_write
+          run_command "identify", MiniMagick::Utilities.windows? ? path_for_windows_quote_space(output_to.to_s) :  output_to.to_s # Verify that we have a good image
+        end
       else # stream
         File.open(path, "rb") do |f|
           f.binmode

--- a/spec/lib/mini_magick_spec.rb
+++ b/spec/lib/mini_magick_spec.rb
@@ -50,4 +50,7 @@ describe MiniMagick do
       MiniMagick.processor = "gm"
     end
   end
+
+  its(:validate_on_create) { should be_true }
+  its(:validate_on_write) { should be_true }
 end


### PR DESCRIPTION
Disabling these flags can save lots of CPU time especially when used in `carrierwave` uploaders with multiple processings
