### PR TITLE
Update readme for 3.8.0's lazy evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ out because the transformations are done on that file)
 ```ruby
 image = MiniMagick::Image.new("input.jpg")
 image.resize "100x100"
+image.run_queue
 ```
 
 Want to get some meta-information out?


### PR DESCRIPTION
3.8.0's lazy evaluation of commands is awesome, but it changes the API for manipulating files in place. You need to call `.run_queue`, or take some other action the object, for the commands to be evaluated.

This should probably be fixed, but in the meantime this PR should make it obvious to anyone else who's just upgraded and is wondering why their commands aren't being run! 
