### PR TITLE
Treat image info keys as strings

### DIFF
--- a/lib/mini_magick/image.rb
+++ b/lib/mini_magick/image.rb
@@ -209,11 +209,12 @@ module MiniMagick
     # @see For reference see http://www.imagemagick.org/script/command-line-options.php#format
     # @return [String, Numeric, Array, Time, Object] Depends on the method called! Defaults to String for unknown commands
     def [](value)
+      value = value.to_s
       retrieved = info(value)
       return retrieved unless retrieved.nil?
 
       # Why do I go to the trouble of putting in newlines? Because otherwise animated gifs screw everything up
-      retrieved = case value.to_s
+      retrieved = case value
                   when 'colorspace'
                     run_command('identify', '-format', '%r\n', path).split("\n")[0].strip
                   when 'format'
@@ -223,9 +224,9 @@ module MiniMagick
                       'identify', '-format', MiniMagick::Utilities.windows? ? '"%w %h\n"' : '%w %h\n', path
                     ).split("\n")[0].split.map { |v| v.to_i }
 
-                    @info[:width] = width_height[0]
-                    @info[:height] = width_height[1]
-                    @info[:dimensions] = width_height
+                    @info['width'] = width_height[0]
+                    @info['height'] = width_height[1]
+                    @info['dimensions'] = width_height
                     nil
                   when 'size'
                     File.size(path) # Do this because calling identify -format "%b" on an animated gif fails!

--- a/spec/lib/mini_magick/image_spec.rb
+++ b/spec/lib/mini_magick/image_spec.rb
@@ -253,6 +253,16 @@ describe MiniMagick::Image do
       image.destroy!
     end
 
+    it 'inspects image meta info as strings' do
+      image = described_class.new(SIMPLE_IMAGE_PATH)
+      expect(image['width']).to be(150)
+      expect(image['height']).to be(55)
+      expect(image['dimensions']).to match_array [150, 55]
+      expect(image['colorspace']).to be_an_instance_of(String)
+      expect(image['format']).to match(/^gif$/i)
+      image.destroy!
+    end
+
     it 'inspects an erroneus image meta info' do
       image = described_class.new(ERRONEOUS_IMAGE_PATH)
       expect(image[:width]).to be(10)


### PR DESCRIPTION
Right now the image caching is broken. If you refer to image['width'], the info will be cached as :width and return nil. Additionally, subsequent requests will run identify again because it thinks its nil, save it again as a symbol, and still return nil. This patch casts it all to a string before it stores it so that it is accessible as a symbol or string. I chose a String instead of a Symbol as the key because it could lead to memory exhaustion otherwise. As a point of interest, the provided documentation mentions accessing keys by string, not hash, so the example itself was broken.
