### PR TITLE
Fix Travis build for Rubinius

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+cache: bundler
+bundler_args: --jobs=1 --retry=3
 rvm:
   - 1.8.7
   - 1.9.2


### PR DESCRIPTION
Installing gems with RubyGems <= 2.4.0 is not thread-safe, and because of that Rubinius was failing when installing gems. The latest RubyGems, 2.4.1, allegedly fixes that problem, so I added

``` sh
$ gem update --system 2.4.1
```

to the Travis build. But that didn't work, the error was still there. So I decided to just not install gems in parallel, and cache the installed gems, so that step should still be fast enough.
