### PR TITLE
Remove implicit queueing

### DIFF
--- a/lib/mini_magick/command_builder.rb
+++ b/lib/mini_magick/command_builder.rb
@@ -1,3 +1,5 @@
+require "forwardable"
+
 module MiniMagick
   class CommandBuilder
     MOGRIFY_COMMANDS = %w(adaptive-blur adaptive-resize adaptive-sharpen adjoin affine alpha annotate antialias append attenuate authenticate auto-gamma auto-level auto-orient backdrop background bench bias black-point-compensation black-threshold blend blue-primary blue-shift blur border bordercolor borderwidth brightness-contrast cache caption cdl channel charcoal chop clamp clip clip-mask clip-path clone clut coalesce colorize colormap color-matrix colors colorspace combine comment compose composite compress contrast contrast-stretch convolve crop cycle debug decipher deconstruct define delay delete density depth descend deskew despeckle direction displace display dispose dissimilarity-threshold dissolve distort dither draw duplicate edge emboss encipher encoding endian enhance equalize evaluate evaluate-sequence extent extract family features fft fill filter flatten flip floodfill flop font foreground format frame function fuzz fx gamma gaussian-blur geometry gravity green-primary hald-clut help highlight-color iconGeometry iconic identify ift immutable implode insert intent interlace interpolate interline-spacing interword-spacing kerning label lat layers level level-colors limit linear-stretch linewidth liquid-rescale list log loop lowlight-color magnify map mask mattecolor median metric mode modulate monitor monochrome morph morphology mosaic motion-blur name negate noise normalize opaque ordered-dither orient page paint path pause pen perceptible ping pointsize polaroid poly posterize precision preview print process profile quality quantize quiet radial-blur raise random-threshold red-primary regard-warnings region remap remote render repage resample resize respect-parentheses reverse roll rotate sample sampling-factor scale scene screen seed segment selective-blur separate sepia-tone set shade shadow shared-memory sharpen shave shear sigmoidal-contrast silent size sketch smush snaps solarize sparse-color splice spread statistic stegano stereo stretch strip stroke strokewidth style subimage-search swap swirl synchronize taint text-font texture threshold thumbnail tile tile-offset tint title transform transparent transparent-color transpose transverse treedepth trim type undercolor unique-colors units unsharp update verbose version view vignette virtual-pixel visual watermark wave weight white-point white-threshold window window-group write)
@@ -20,6 +22,9 @@ module MiniMagick
     def args
       @args.map { |arg| Utilities.escape(arg) }
     end
+
+    extend Forwardable
+    def_delegators :@args, :empty?, :any?, :clear
 
     # Add each mogrify command in both underscore and dash format
     MOGRIFY_COMMANDS.each do |mogrify_command|

--- a/spec/lib/mini_magick/image_spec.rb
+++ b/spec/lib/mini_magick/image_spec.rb
@@ -231,8 +231,7 @@ describe MiniMagick::Image do
 
     it "raises error when imagemagick raised an error during processing" do
       image = described_class.open(SIMPLE_IMAGE_PATH)
-      image.rotate "invalid_value"
-      expect { image.run_queue }.to raise_error(MiniMagick::Error)
+      expect { image.rotate "invalid_value" }.to raise_error(MiniMagick::Error)
     end
 
     it 'inspects image meta info' do
@@ -278,6 +277,13 @@ describe MiniMagick::Image do
       expect(image[:width]).to be(20)
       expect(image[:height]).to be(30)
       expect(image[:format]).to match(/^gif$/i)
+    end
+
+    it "clears the info after destructive commands" do
+      image = described_class.open(SIMPLE_IMAGE_PATH)
+      old_width = image[:width]
+      image.resize '20x30!'
+      expect(image[:width]).not_to eq old_width
     end
 
     it 'resizes an image with minimum dimensions' do


### PR DESCRIPTION
There are 2 cases where commands are being queued: when using `#combine_options` and when using `#method_missing` methods (like `#resize`). This commit drops the `#method_missing` queueing.

The reason for this is that the code becomes much more complicated when at the beginning of each "terminal" method we have to run the queue if there are any queued commands. But when we write `image.resize("150x150")`, we don't expect it to be queued. I can imagine a user writing the following code, and being suprised it isn't working:

``` ruby
path = "path/to/image.jpg"
image = MiniMagick::Image.new(path)
image.resize("150x150")

# User: "Done! The image is cropped."
```

We already have a great API for queueing commands -- `#combine_options`, which I'm sure users have already adopted, and that no-one will be suprised if the regular commands aren't queueing anymore.

I will thoroughly update the README before the next release.

Fixes #230.
