### PR TITLE
Fixed #+ method so it only affects the last argument

### DIFF
--- a/lib/mini_magick/tool.rb
+++ b/lib/mini_magick/tool.rb
@@ -140,7 +140,7 @@ module MiniMagick
     # @return [self]
     #
     def +(value = nil)
-      args.last.sub!(/^-/, '+')
+      args[-1] = args[-1].sub(/^-/, '+')
       args << value.to_s if value
       self
     end

--- a/spec/lib/mini_magick/tool_spec.rb
+++ b/spec/lib/mini_magick/tool_spec.rb
@@ -55,9 +55,10 @@ RSpec.describe MiniMagick::Tool do
 
   describe "#+" do
     it "switches the last option to + form" do
+      subject.help
       subject.help.+
       subject.debug.+ 8
-      expect(subject.args).to eq %W[+help +debug 8]
+      expect(subject.args).to eq %W[-help +help +debug 8]
     end
   end
 


### PR DESCRIPTION
The `gsub!` was also affecting all other instances of the same argument, since they are in fact references to the same string (same `object_id`). So if you used for instance `i.opaque.+` once, and later just `i.opaque`, both where rendered as `+opaque` in the command-line.
