### PR TITLE
Caching of raw info values.

### DIFF
--- a/lib/mini_magick/image/info.rb
+++ b/lib/mini_magick/image/info.rb
@@ -89,7 +89,10 @@ module MiniMagick
       end
 
       def raw(value)
-        identify { |b| b.format(value) }
+        key = "raw:#{value}"
+        @info.fetch(key) do
+          @info[key] = identify { |b| b.format(value) }
+        end
       end
 
       def identify


### PR DESCRIPTION
Probably other 'non-cheap' info should also be cached, especially as some can be expensive.

This is a solution proposal. Please feel free to differ :p Not sure if this is the intent of the `@info` hash, but by making another, we'd need to clear it the same way as `@info` in the `#clear` method.
