### PR TITLE
Added support for multi-parameter options

### DIFF
--- a/lib/mini_magick/tool.rb
+++ b/lib/mini_magick/tool.rb
@@ -132,6 +132,16 @@ module MiniMagick
     end
 
     ##
+    # Merges a list of raw options.
+    #
+    # @return [self]
+    #
+    def merge!(new_args)
+      new_args.each { |arg| self << arg }
+      self
+    end
+
+    ##
     # Changes the last operator to its "plus" form.
     #
     # @example
@@ -142,9 +152,9 @@ module MiniMagick
     #
     # @return [self]
     #
-    def +(value = nil)
+    def +(*values)
       args[-1] = args[-1].sub(/^-/, '+')
-      args << value.to_s if value
+      self.merge!(values)
       self
     end
 
@@ -196,9 +206,9 @@ module MiniMagick
       #
       def option(*options)
         options.each do |option|
-          define_method(option[1..-1].gsub('-', '_')) do |value = nil|
+          define_method(option[1..-1].gsub('-', '_')) do |*values|
             self << option
-            self << value.to_s if value
+            self.merge!(values)
             self
           end
         end

--- a/spec/lib/mini_magick/tool_spec.rb
+++ b/spec/lib/mini_magick/tool_spec.rb
@@ -48,8 +48,16 @@ RSpec.describe MiniMagick::Tool do
 
   describe "#<<" do
     it "adds argument to the args list" do
-      subject << "foo" << "bar"
-      expect(subject.args).to eq %W[foo bar]
+      subject << "foo" << "bar" << 123
+      expect(subject.args).to eq %W[foo bar 123]
+    end
+  end
+
+  describe "#merge!" do
+    it "adds arguments to the args list" do
+      subject << "pre-existing"
+      subject.merge! ["foo", 123]
+      expect(subject.args).to eq %W[pre-existing foo 123]
     end
   end
 
@@ -57,8 +65,9 @@ RSpec.describe MiniMagick::Tool do
     it "switches the last option to + form" do
       subject.help
       subject.help.+
-      subject.debug.+ 8
-      expect(subject.args).to eq %W[-help +help +debug 8]
+      subject.debug.+ "foo"
+      subject.debug.+ 8, "bar"
+      expect(subject.args).to eq %W[-help +help +debug foo +debug 8 bar]
     end
   end
 


### PR DESCRIPTION
Parameters with more than one option, like `-morphology` or `-annotate` are not supported anymore, are they? Had to use `<<` to add the extra options that are not as tidy, as in:

```
  cmd.morphology "Close:1"
  cmd << "Disk:8.3"
```

This is a proposed implementation if you would like to re-implement that feature.
