### PR TITLE
Add respond_to_missing? to complement method_missing

### DIFF
--- a/lib/mini_magick/image.rb
+++ b/lib/mini_magick/image.rb
@@ -358,6 +358,10 @@ module MiniMagick
       end
     end
 
+    def respond_to_missing?(method_name, include_private = false)
+      MiniMagick::Tool::Mogrify.new.respond_to?(method_name, include_private)
+    end
+
     ##
     # Writes the temporary file out to either a file location (by passing in a
     # String) or by passing in a Stream that you can #write(chunk) to

--- a/spec/lib/mini_magick/image_spec.rb
+++ b/spec/lib/mini_magick/image_spec.rb
@@ -299,19 +299,31 @@ require "stringio"
         end
       end
 
-      describe "#method_missing" do
-        it "executes the command correctly" do
-          expect { subject.resize '20x30!' }
-            .to change { subject.dimensions }.to [20, 30]
+      describe "missing methods" do
+        context "for a known method" do
+          it "is executed by #method_missing" do
+            expect { subject.resize '20x30!' }
+              .to change { subject.dimensions }.to [20, 30]
+          end
+
+          it "returns self" do
+            expect(subject.resize('20x30!')).to eq subject
+          end
+
+          it "can be responed to" do
+            expect(subject.respond_to?(:resize)).to eq true
+          end
         end
 
-        it "fails with a correct NoMethodError" do
-          expect { subject.foo }
-            .to raise_error(NoMethodError, /MiniMagick::Image/)
-        end
+        context "for an unknown method" do
+          it "fails with a NoMethodError" do
+            expect { subject.foo }
+              .to raise_error(NoMethodError, /MiniMagick::Image/)
+          end
 
-        it "returns self" do
-          expect(subject.resize('20x30!')).to eq subject
+          it "cannot be responded to" do
+            expect(subject.respond_to?(:foo)).to eq false
+          end
         end
       end
 


### PR DESCRIPTION
The `#respond_to_missing?` hook is the complement of `#method_missing`,
used by `#respond_to?`, `#method`, etc... to do the right thing. In this
case, since `#method_missing` is implemented in terms of an instance of
`MiniMagick::Tool::Mogrify`, we use an instance of that class to
determine if objects of this class can respond to those missing
messages.
