### PR TITLE
fix - require 'mini_gmagick'

### DIFF
--- a/lib/mini_gmagick.rb
+++ b/lib/mini_gmagick.rb
@@ -1,3 +1,3 @@
 require 'mini_magick'
 
-MiniMagick.processor = :graphicsmagick
+MiniMagick.processor = :gm


### PR DESCRIPTION
Fix for cases where `require 'mini_gmagick'`.
I understand you've made some changes to setting #processor, and setting it directly is pretty much deprecated (I think).

There may be a more correct way of doing this/you may just want to drop this file or issue a deprecation warning or whatever.

I agree that using a configure block makes more sense, as below: 

``` ruby
MiniMagick.configure do |config|
  config.cli = :graphicsmagick
end
```

Anyway, thanks for the gem!
