### PR TITLE
#unshift lib/ instead of #push to the $LOAD_PATH

### DIFF
--- a/mini_magick.gemspec
+++ b/mini_magick.gemspec
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path('../lib', __FILE__)
+$:.unshift File.expand_path('../lib', __FILE__)
 
 require 'mini_magick/version'
 


### PR DESCRIPTION
Hi,

This change ensures that the version encoded in the gemspec is the right one, regardless of the fact that another version maybe installed somewhere else on the system.
