### PR TITLE
Add undocumented graphicsmagick mogrify options

### DIFF
--- a/lib/mini_magick/tool.rb
+++ b/lib/mini_magick/tool.rb
@@ -252,7 +252,10 @@ module MiniMagick
         help_page = tool.call(false, stderr: false)
 
         cli_options = help_page.scan(/^\s+-[a-z\-]+/).map(&:strip)
-        cli_options << "-gravity" if @tool_name == "mogrify" && MiniMagick.graphicsmagick?
+        if @tool_name == "mogrify" && MiniMagick.graphicsmagick?
+          # These options were undocumented before 2015-06-14 (see gm bug 302)
+          cli_options |= %w[-box -convolve -gravity -linewidth -mattecolor -render -shave]
+        end
         cli_options
       end
 

--- a/spec/lib/mini_magick/tool_spec.rb
+++ b/spec/lib/mini_magick/tool_spec.rb
@@ -109,9 +109,13 @@ RSpec.describe MiniMagick::Tool do
   end
 
   # https://github.com/minimagick/minimagick/issues/264
-  it "adds the #gravity method to GraphicsMagick's mogrify" do
+  # http://sourceforge.net/p/graphicsmagick/bugs/302/
+  it "adds undocumented methods to GraphicsMagick's mogrify" do
     MiniMagick.with_cli :graphicsmagick do
-      expect(MiniMagick::Tool::Mogrify.new).to respond_to(:gravity)
+      mogrify = MiniMagick::Tool::Mogrify.new
+      %w[box convolve gravity linewidth mattecolor render shave].each do |method|
+        expect(mogrify).to respond_to(method)
+      end
     end
   end
 


### PR DESCRIPTION
These options were available for a very long time, but missing in `gm mogrify -help` output and could not be used. A set union is used to add the missing options so that the options aren't duplicated once a
fixed graphicsmagick version gets released (should be included in 1.3.22).

More information about the problem can be found in issue #264.