### PR TITLE
Maintain .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,6 @@ matrix:
   allow_failures:
     - rvm: ruby-head
 before_install:
+  - sudo apt-get update
   - sudo apt-get install imagemagick libmagickcore-dev libmagickwand-dev
   - sudo apt-get install -qq graphicsmagick

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install imagemagick libmagickcore-dev libmagickwand-dev
   - sudo apt-get install -qq graphicsmagick
+  - gem update bundler


### PR DESCRIPTION
Build has errored on Travis CI.

e.g. https://travis-ci.org/minimagick/minimagick/jobs/103772458

I have two reasons why I think so.

1. [Build fails because package can't be located](https://github.com/travis-ci/travis-ci/issues/5221)
2. [bundle install failing](https://github.com/travis-ci/travis-ci/issues/5239)

Maybe it fixed by this PR.

But I don't know the reason why [JRuby build has errored](https://travis-ci.org/minimagick/minimagick/builds/91565243) :cry: 

Thanks.
