### PR TITLE
Ruby 2.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
+  - 2.3.0
   - rbx
   - jruby
   - ruby-head

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ MiniMagick has been tested on following Rubies:
 * MRI 2.0
 * MRI 2.1
 * MRI 2.2
+* MRI 2.3
 * Rubinius
 * JRuby (1.7.18 and later)
 


### PR DESCRIPTION
Would you like to support MRI 2.3?
The reasons are as follows.

* Ruby 2.3 is highly compatible with Ruby 2.2
* Pass the testing

Thanks.