### PR TITLE
Implemented return of STDOUT

### DIFF
--- a/lib/mini_magick.rb
+++ b/lib/mini_magick.rb
@@ -43,7 +43,7 @@ module MiniMagick
   #
   # @return [String]
   def self.cli_version
-    output = MiniMagick::Tool::Identify.new(&:version)
+    output = MiniMagick::Tool::Identify.new(&:version).first
     output[/\d+\.\d+\.\d+(-\d+)?/]
   end
 

--- a/lib/mini_magick/image.rb
+++ b/lib/mini_magick/image.rb
@@ -139,6 +139,16 @@ module MiniMagick
     attr_reader :tempfile
 
     ##
+    # @return [String] Output of last stdout
+    #
+    attr_reader :stdout
+
+    ##
+    # @return [String] Output of last stderr
+    #
+    attr_reader :stderr
+
+    ##
     # Create a new {MiniMagick::Image} object.
     #
     # _DANGER_: The file location passed in here is the *working copy*. That
@@ -302,7 +312,7 @@ module MiniMagick
     # @return [Array<MiniMagick::Image>]
     #
     def layers
-      layers_count = identify.lines.count
+      layers_count = identify.first.lines.count
       layers_count.times.map do |idx|
         MiniMagick::Image.new("#{path}[#{idx}]")
       end
@@ -502,7 +512,7 @@ module MiniMagick
     end
 
     def mogrify(page = nil)
-      MiniMagick::Tool::Mogrify.new do |builder|
+      @stdout, @stderr = MiniMagick::Tool::Mogrify.new do |builder|
         builder.instance_eval do
           def format(*args)
             fail NoMethodError,

--- a/lib/mini_magick/image/info.rb
+++ b/lib/mini_magick/image/info.rb
@@ -139,7 +139,7 @@ module MiniMagick
         MiniMagick::Tool::Identify.new do |builder|
           yield builder if block_given?
           builder << path
-        end
+        end.first
       end
 
       def decode_comma_separated_ascii_characters(encoded_value)

--- a/lib/mini_magick/shell.rb
+++ b/lib/mini_magick/shell.rb
@@ -20,9 +20,9 @@ module MiniMagick
         fail MiniMagick::Error, stderr
       end if options.fetch(:whiny, true)
 
-      $stderr.print(stderr) unless options[:stderr] == false
+    $stderr.print(stderr) unless options[:stderr] == false
 
-      stdout
+      [stdout, stderr]
     end
 
     def execute(command)

--- a/lib/mini_magick/tool.rb
+++ b/lib/mini_magick/tool.rb
@@ -72,11 +72,11 @@ module MiniMagick
     #   some ImageMagick's commands (`identify -help`) return exit code 1,
     #   even though no error happened.
     #
-    # @return [String] Output of the command
+    # @return [Array] Output and Errors of command
     #
     def call(whiny = @whiny, options = {})
       shell = MiniMagick::Shell.new
-      shell.run(command, options.merge(whiny: whiny)).strip
+      shell.run(command, options.merge(whiny: whiny)).map(&:strip)
     end
 
     ##
@@ -220,7 +220,7 @@ module MiniMagick
         tool << "-help"
         help_page = tool.call(false, stderr: false)
 
-        cli_options = help_page.scan(/^\s+-[a-z\-]+/).map(&:strip)
+        cli_options = help_page.first.scan(/^\s+-[a-z\-]+/).map(&:strip)
         if tool.name == "mogrify" && MiniMagick.graphicsmagick?
           # These options were undocumented before 2015-06-14 (see gm bug 302)
           cli_options |= %w[-box -convolve -gravity -linewidth -mattecolor -render -shave]

--- a/spec/lib/mini_magick/image_spec.rb
+++ b/spec/lib/mini_magick/image_spec.rb
@@ -532,7 +532,7 @@ require "stringio"
 
         it "collapses the image to one frame" do
           subject.collapse!
-          expect(subject.identify.lines.count).to eq 1
+          expect(subject.identify.first.lines.count).to eq 1
         end
 
         it "keeps the extension" do
@@ -576,20 +576,20 @@ require "stringio"
 
       describe "#identify" do
         it "returns the output of identify" do
-          expect(subject.identify).to match(subject.type)
+          expect(subject.identify.first).to match(subject.type)
         end
 
         it "yields an optional block" do
           output = subject.identify do |b|
             b.verbose
-          end
+          end.first
           expect(output).to match("Format:")
         end
       end
 
       describe "#run_command" do
         it "runs the given command" do
-          output = subject.run_command("identify", "-format", "%w", subject.path)
+          output = subject.run_command("identify", "-format", "%w", subject.path).first
           expect(output).to eq subject.width.to_s
         end
       end

--- a/spec/lib/mini_magick/shell_spec.rb
+++ b/spec/lib/mini_magick/shell_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe MiniMagick::Shell do
     it "returns stdout" do
       allow(subject).to receive(:execute).and_return(["stdout", "stderr", 0])
       output = subject.run(%W[foo])
-      expect(output).to eq "stdout"
+      expect(output).to eq ["stdout", "stderr"]
     end
 
     it "uses stderr for error messages" do
@@ -29,7 +29,7 @@ RSpec.describe MiniMagick::Shell do
 
     it "raises errors only in whiny mode" do
       allow(subject).to receive(:execute).and_return(["stdout", "", 127])
-      expect(subject.run(%W[foo], whiny: false)).to eq "stdout"
+      expect(subject.run(%W[foo], whiny: false)).to eq ["stdout", ""]
     end
 
     it "prints to stderr output to $stderr in non-whiny mode" do

--- a/spec/lib/mini_magick/tool_spec.rb
+++ b/spec/lib/mini_magick/tool_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe MiniMagick::Tool do
   describe "#call" do
     it "calls the shell to run the command" do
       subject << image_path(:gif)
-      output = subject.call
+      output = subject.call.first
       expect(output).to match("GIF")
     end
 
     it "strips the output" do
       subject << image_path
-      output = subject.call
+      output = subject.call.first
       expect(output).not_to end_with("\n")
     end
   end
@@ -21,7 +21,7 @@ RSpec.describe MiniMagick::Tool do
     it "accepts a block, and immediately executes the command" do
       output = described_class.new("identify") do |builder|
         builder << image_path(:gif)
-      end
+      end.first
       expect(output).to match("GIF")
     end
   end


### PR DESCRIPTION
I figured I'd make this a PR just to create a conversation, even if you don't go for it since it's such a major breaking change.

I forked this for myself, for a project where I'm using threads, so capturing `$stderr` temporarily isn't working.

This implements the ability to get `stdin` and `stdout` from an image (last operation) and `stdin, stdout = MiniMagick::Tool::*`