### PR TITLE
MiniMagick::Tools accepts block to handle output

### DIFF
--- a/lib/mini_magick/tool.rb
+++ b/lib/mini_magick/tool.rb
@@ -67,16 +67,30 @@ module MiniMagick
     #   mogrify << "path/to/image.jpg"
     #   mogrify.call # executes `mogrify -resize 500x500 path/to/image.jpg`
     #
+    # @example
+    #   mogrify = MiniMagick::Tool::Mogrify.new
+    #   # build the command
+    #   mogrify.call do |stdout, stderr, status|
+    #   # handle the case
+    #   end
+    #
     # @param whiny [Boolean] Whether you want an error to be raised when
     #   ImageMagick returns an exit code of 1. You may want this because
     #   some ImageMagick's commands (`identify -help`) return exit code 1,
     #   even though no error happened.
     #
-    # @return [String] Output of the command
+    # @return [String, Integer] If no block is given, returns the output of the
+    #   command, if block is given, returns the exit status of the command
     #
     def call(whiny = @whiny, options = {})
       shell = MiniMagick::Shell.new
-      shell.run(command, options.merge(whiny: whiny)).strip
+      if block_given?
+        stdin, stdout, status = shell.execute(command)
+        yield stdin, stdout, status
+        status
+      else
+        shell.run(command, options.merge(whiny: whiny)).strip
+      end
     end
 
     ##

--- a/spec/lib/mini_magick/tool_spec.rb
+++ b/spec/lib/mini_magick/tool_spec.rb
@@ -15,6 +15,16 @@ RSpec.describe MiniMagick::Tool do
       output = subject.call
       expect(output).not_to end_with("\n")
     end
+
+    it "accepts a block, and yields stdin, stdout and exit status" do
+      allow_any_instance_of(Shell).to receive(:execute).and_return(["stdout", "stderr", 1])
+      instance = subject
+      instance.call do |stdout, stderr, status|
+        expect(stdout).to eq "stdout"
+        expect(stderr).to eq "stderr"
+        expect(status).to be 1
+      end
+    end
   end
 
   describe ".new" do


### PR DESCRIPTION
As discussed in https://github.com/minimagick/minimagick/pull/359#issuecomment-198548873

Example usage:

```ruby
convert = MiniMagick::Tool::Convert.new
convert.call do |stdout, stderr, status|
  fail if stderr =~ /geometry/
end
```

Includes test, documentation and example. Please let me know if there's anything you think should be cleaned up.