### PR TITLE
Split exif lines on the first '='-character

### DIFF
--- a/lib/mini_magick/image/info.rb
+++ b/lib/mini_magick/image/info.rb
@@ -81,7 +81,7 @@ module MiniMagick
       def exif
         @info["exif"] ||= (
           output = self["%[EXIF:*]"]
-          pairs = output.gsub(/^exif:/, "").split("\n").map { |line| line.split("=") }
+          pairs = output.gsub(/^exif:/, "").split("\n").map { |line| line.split("=", 2) }
           Hash[pairs].tap do |hash|
             ASCII_ENCODED_EXIF_KEYS.each do |key|
               next unless hash.has_key?(key)


### PR DESCRIPTION
It failed on lines with '='-characters in the exif values.

It should only make a key on the part before the '='-character, and the value should be the part after. 