### PR TITLE
Handle newline characters in EXIF tags

### DIFF
--- a/lib/mini_magick/image/info.rb
+++ b/lib/mini_magick/image/info.rb
@@ -81,7 +81,7 @@ module MiniMagick
       def exif
         @info["exif"] ||= (
           output = self["%[EXIF:*]"]
-          pairs = output.gsub(/^exif:/, "").split("\n").map { |line| line.split("=", 2) }
+          pairs = output.gsub(/^exif:/, "").split("\n").map { |line| line.split("=", 2) }.reject(&:empty?)
           Hash[pairs].tap do |hash|
             ASCII_ENCODED_EXIF_KEYS.each do |key|
               next unless hash.has_key?(key)

--- a/spec/lib/mini_magick/image/info_spec.rb
+++ b/spec/lib/mini_magick/image/info_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+["ImageMagick", "GraphicsMagick"].each do |cli|
+  RSpec.context "With #{cli}", cli: cli.downcase.to_sym do
+    describe MiniMagick::Image::Info do
+      describe "#exif" do
+        subject { described_class.new(image_path(:exif)) }
+
+        context "with tag containing a newline" do
+          let(:exif_output) do
+            <<-EOS
+exif:ImageUniqueID=A16LSIA00VM A16LSIL02SM
+
+exif:ImageWidth=1200
+            EOS
+          end
+
+          it "handles newlines" do
+            allow(subject).to receive(:identify).and_return(exif_output)
+            expect(subject.exif["ImageUniqueID"]).to eq("A16LSIA00VM A16LSIL02SM")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I've found that certain JPEG files trigger an **ArgumentError: invalid number of elements (0 for 1..2)** upon accessing their EXIF attributes using the #exif method. [This](http://orig10.deviantart.net/2c2d/f/2016/317/e/7/chrysalis_plush__1_by_thebigm585-dao8z0l.jpg) is the only such file I have at hand but I've encountered this problem several times before. It is likely related to #372 and is caused by a newline character in an EXIF tag. Here's a part of `identify -verbose` output:
```
Image: exif.jpg
  Format: JPEG (Joint Photographic Experts Group JFIF format)
  Properties:
    exif:ColorSpace: sRGB
    exif:ImageUniqueID: A16LSIA00VM A16LSIL02SM
  
    exif:ImageWidth: 1200
    exif:Orientation: Top-left
```
The patch fixes the problem for me. If you think it warrants a test case, I can write it, but I'll have to add another file to test fixtures and I'm not sure about your policies regarding that.