### PR TITLE
Quote parameters for format argument

### DIFF
--- a/lib/mini_magick/image/info.rb
+++ b/lib/mini_magick/image/info.rb
@@ -42,7 +42,7 @@ module MiniMagick
 
       def cheap_info(value)
         @info.fetch(value) do
-          format, width, height, size = self["%m %w %h %b"].split(" ")
+          format, width, height, size = self['"%m %w %h %b"'].split(" ")
 
           path = @path
           path = path.match(/\[\d+\]$/).pre_match if path =~ /\[\d+\]$/
@@ -73,7 +73,7 @@ module MiniMagick
       def resolution(unit = nil)
         output = identify do |b|
           b.units unit if unit
-          b.format "%x %y"
+          b.format '"%x %y"'
         end
         output.split(" ").map(&:to_i)
       end


### PR DESCRIPTION
I tried to deploy my application to a Linux/JRuby environment, and found that my image size validations failed when 'identify' returned with errors like this:

unable to open image '%w'
no decode delegate for this image format '%w'

The man page defines the 'format' argument like this: '-format "string"' - so I have quoted the parameters and the error was gone. (For some reason, I did not encounter this error on Windows, while using my development configuration.)