### PR TITLE
Read process output before waiting for exit

### DIFF
--- a/lib/mini_magick/shell.rb
+++ b/lib/mini_magick/shell.rb
@@ -52,9 +52,11 @@ module MiniMagick
       pid, stdin, stdout, stderr = POSIX::Spawn.popen4(*command)
       [stdin, stdout, stderr].each(&:binmode)
       stdin.write(options[:stdin].to_s)
+      out = stdout.read
+      err = stderr.read
       Process.waitpid(pid)
 
-      [stdout.read, stderr.read, $?]
+      [out, err, $?]
     end
 
     def log(command, &block)

--- a/spec/lib/mini_magick/shell_spec.rb
+++ b/spec/lib/mini_magick/shell_spec.rb
@@ -55,6 +55,13 @@ RSpec.describe MiniMagick::Shell do
           expect(status).to eq 1
         end
 
+        it "handles larger output" do
+          Timeout.timeout(1) do
+            stdout, _, _ = subject.execute(%W[convert #{image_path(:gif)} -])
+            expect(stdout).to match("GIF")
+          end
+        end
+
         it "returns an appropriate response when command wasn't found" do
           stdout, stderr, code = subject.execute(%W[unexisting command])
           expect(code).to eq 127


### PR DESCRIPTION
The process output is buffered, and the buffer size is limited. The
process will block on writing to stdout when the buffer is full. That's
why we need to read all data from stdout before waiting for the process
to exit.

I noticed the issue with generating a 200K image.