### PR TITLE
Support Ruby 2.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
-  - 2.3.0
+  - 2.3.3
+  - 2.4.0
   - jruby
   - ruby-head
 matrix:

--- a/spec/lib/mini_magick/image_spec.rb
+++ b/spec/lib/mini_magick/image_spec.rb
@@ -313,18 +313,18 @@ require "stringio"
 
       describe "#[]" do
         it "inspects image meta info" do
-          expect(subject[:width]).to be_a(Fixnum)
-          expect(subject[:height]).to be_a(Fixnum)
-          expect(subject[:dimensions]).to all(be_a(Fixnum))
+          expect(subject[:width]).to be_a(Integer)
+          expect(subject[:height]).to be_a(Integer)
+          expect(subject[:dimensions]).to all(be_a(Integer))
           expect(subject[:colorspace]).to be_a(String)
           expect(subject[:format]).to match(/[A-Z]/)
           expect(subject[:signature]).to match(/[[:alnum:]]{64}/)
         end
 
         it "supports string keys" do
-          expect(subject["width"]).to be_a(Fixnum)
-          expect(subject["height"]).to be_a(Fixnum)
-          expect(subject["dimensions"]).to all(be_a(Fixnum))
+          expect(subject["width"]).to be_a(Integer)
+          expect(subject["height"]).to be_a(Integer)
+          expect(subject["dimensions"]).to all(be_a(Integer))
           expect(subject["colorspace"]).to be_a(String)
           expect(subject["format"]).to match(/[A-Z]/)
           expect(subject['signature']).to match(/[[:alnum:]]{64}/)
@@ -343,13 +343,13 @@ require "stringio"
       it "has attributes" do
         expect(subject.type).to match(/^[A-Z]+$/)
         expect(subject.mime_type).to match(/^image\/[a-z]+$/)
-        expect(subject.width).to be_a(Fixnum).and be_nonzero
-        expect(subject.height).to be_a(Fixnum).and be_nonzero
-        expect(subject.dimensions).to all(be_a(Fixnum))
+        expect(subject.width).to be_a(Integer).and be_nonzero
+        expect(subject.height).to be_a(Integer).and be_nonzero
+        expect(subject.dimensions).to all(be_a(Integer))
         expect(subject.size).to be_a(Integer).and be_nonzero
         expect(subject.human_size).to be_a(String).and be_nonempty
         expect(subject.colorspace).to be_a(String)
-        expect(subject.resolution).to all(be_a(Fixnum))
+        expect(subject.resolution).to all(be_a(Integer))
         expect(subject.signature).to match(/[[:alnum:]]{64}/)
       end
 


### PR DESCRIPTION
[Ruby 2.4.0 has been released](https://www.ruby-lang.org/en/news/2016/12/25/ruby-2-4-0-released). Then this Ruby version is available on Travis CI.

http://rubies.travis-ci.org

And, Ruby 2.4.0 unifies Fixnum and Bignum into Integer.

https://bugs.ruby-lang.org/issues/12005

Fix the following deprecated warning in Ruby 2.4.0.

`warning: constant ::Fixnum is deprecated`

Thanks.