### PR TITLE
Fix a build error in Travis CI

### DIFF
--- a/mini_magick.gemspec
+++ b/mini_magick.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec', '~> 3.1.0'
+  s.add_development_dependency 'rspec', '~> 3.5.0'
   s.add_development_dependency 'posix-spawn' unless RUBY_PLATFORM == 'java'
 end


### PR DESCRIPTION
Follow up to #388.

This PR will fix a following build error.

```sh
$ bundle exec rake
rake aborted!
NoMethodError: undefined method `last_comment' for #<Rake::Application:0x000000018b8278>
/home/travis/build/minimagick/minimagick/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.1.7/lib/rspec/core/rake_task.rb:104:in `define'
/home/travis/build/minimagick/minimagick/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.1.7/lib/rspec/core/rake_task.rb:80:in `initialize'
/home/travis/build/minimagick/minimagick/Rakefile:16:in `new'
/home/travis/build/minimagick/minimagick/Rakefile:16:in `<top (required)>'
/home/travis/build/minimagick/minimagick/vendor/bundle/ruby/2.4.0/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
```

An above error is caused by a combination of Rake and RSpec versions.

:warning: The important point, `last_comment` method has been removed from latest version of Rake (12.0.0).

https://github.com/ruby/rake/commit/11bbb7c20bb9bae42310e0ab9294a76658fe158e

This problem will be solved by upgrade RSpec. That is the way this PR taking.

https://travis-ci.org/minimagick/minimagick/jobs/187724285

Thanks.