### PR TITLE
Add support for Image#get_pixels

### DIFF
--- a/lib/mini_magick/image.rb
+++ b/lib/mini_magick/image.rb
@@ -532,5 +532,36 @@ module MiniMagick
       path =~ /\[\d+\]$/
     end
 
+
+    ##
+    # Returns a matrix of pixels corresponding to the size given.
+    # Each element is a triplet of the RGB values of that pixel.
+    #
+    #
+    # @example
+    #   image = MiniMagick::Image.open("image.jpg")
+    #   image.get_pixels # Entire image
+    #   image.get_pixels(10, 10, 30, 30) # 30x30 rectangle at offset 10+10
+    #
+    # @return [Array] Matrix of each color of each pixel
+    #
+    def get_pixels(*args)
+      convert = MiniMagick::Tool::Convert.new
+      if args.any?
+        raise ArgumentError, "must provide 4 arguments: (x, y, columns, rows)" if args.size != 4
+        x, y, columns, rows = args
+        convert << "#{path}[#{rows}x#{columns}+#{x}+#{y}]"
+      else
+        columns = width
+        convert << path
+      end
+
+      convert.depth(8)
+      convert << "RGB:-"
+      content = convert.call
+
+      pixels = content.unpack("C*")
+      pixels.each_slice(3).each_slice(columns).to_a
+    end
   end
 end

--- a/spec/lib/mini_magick/image_spec.rb
+++ b/spec/lib/mini_magick/image_spec.rb
@@ -612,6 +612,27 @@ require "stringio"
           expect(output).to eq subject.width.to_s
         end
       end
+
+      describe "#get_pixels", skip_cli: :graphicsmagick do
+        it "runs the command" do
+          expect(subject.get_pixels.class).to eq Array
+        end
+
+        it "returns a matrix of correct dimensions when called on full image"  do
+          output = subject.get_pixels
+          expect(output.size).to eq subject.height
+          expect(output.first.size).to eq subject.width
+          expect(output[0][0].size).to eq 3
+        end
+
+        it "returns a matrix of correct dimensions when called a part of the image" do
+          x, y, columns, rows = 10, 10, 30, 40
+          output = subject.get_pixels x, y, columns, rows
+          expect(output.size).to eq rows
+          expect(output.first.size).to eq columns
+          expect(output[0][0].size).to eq 3
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Uses code from @janko-m in #365 and tries to implement the same functionality as RMagick's [get_pixels](https://rmagick.github.io/image2.html#get_pixels). I wasn't able to get it to work on GraphicsMagick, as the syntax seems different.

The method returns an array of arrays with each array containing a triplet: the RGB values of that pixel. Also supports defining a rectangle inside the image to get pixels from.

Usage:

```ruby
> image = MiniMagick::Image.new "spec/fixtures/default.jpg"
=> #<MiniMagick::Image:0x000000027f54c0 @path="spec/fixtures/default.jpg", @tempfile=nil, @info=#<MiniMagick::Image::Info:0x000000027f5498 @path="spec/fixtures/default.jpg", @info={}>>
> image.get_pixels.size
=> 276
> image.get_pixels.first
=> [[72, 58, 45], [72, 59, 42], [72, 60, 38], [72, 60, 38], [72, 59, 40], # (...)
```

Someone should probably review, I'm new to contributing to this library.
Closes #365.

