### PR TITLE
Handle images that do not have EXIF data with graphicsmagick

### DIFF
--- a/lib/mini_magick/image/info.rb
+++ b/lib/mini_magick/image/info.rb
@@ -101,6 +101,7 @@ module MiniMagick
               end
             when :graphicsmagick
               key, value = line.split("=", 2)
+              next unless value
               value.gsub!("\\012", "\n") # convert "\012" characters to newlines
               hash[key] = value
             end


### PR DESCRIPTION
Previously you would get this for some images:

```
image = MiniMagick::Image.open("https://XXX.s3.amazonaws.com/1e69dcf3-2e53-4c4a-a247-476a5eaf97ae.jpeg")
2.3.1 :050 > image.exif
Line: unknown; unknown,
NoMethodError: undefined method `gsub!' for nil:NilClass
	from (irb):39:in `block in exif'
	from (irb):24:in `each_line'
	from (irb):24:in `exif'
	from /home/vagrant/.rvm/gems/ruby-2.3.1/gems/mini_magick-4.8.0/lib/mini_magick/image/info.rb:29:in `[]'
	from /home/vagrant/.rvm/gems/ruby-2.3.1/gems/mini_magick-4.8.0/lib/mini_magick/image.rb:132:in `block in attribute'
```

Now, `image.exif` will return an empty hash if there is no EXIF data.

Do you need anything special for contributions?

Cheers, Nigel (@wtfiwtz)