### PR TITLE
Suppress deprecation warnings in production code

### DIFF
--- a/lib/mini_magick/configuration.rb
+++ b/lib/mini_magick/configuration.rb
@@ -39,12 +39,12 @@ module MiniMagick
     #
     attr_accessor :timeout
     ##
-    # When set to `true`, it outputs each command to STDOUT in their shell
+    # When get to `true`, it outputs each command to STDOUT in their shell
     # version.
     #
     # @return [Boolean]
     #
-    attr_accessor :debug
+    attr_reader :debug
     ##
     # Logger for {#debug}, default is `MiniMagick::Logger.new(STDOUT)`, but
     # you can override it, for example if you want the logs to be written to
@@ -168,6 +168,10 @@ module MiniMagick
       @cli_path || @processor_path
     end
 
+    ##
+    # When set to `true`, it outputs each command to STDOUT in their shell
+    # version.
+    #
     def debug=(value)
       warn "MiniMagick.debug is deprecated and will be removed in MiniMagick 5. Use `MiniMagick.logger.level = Logger::DEBUG` instead."
       logger.level = value ? Logger::DEBUG : Logger::INFO

--- a/lib/mini_magick/configuration.rb
+++ b/lib/mini_magick/configuration.rb
@@ -11,8 +11,6 @@ module MiniMagick
     # @return [Symbol] `:imagemagick`, `:imagemagick7`, or `:graphicsmagick`
     #
     attr_accessor :cli
-    # @private (for backwards compatibility)
-    attr_accessor :processor
 
     ##
     # If you don't have the CLI tools in your PATH, you can set the path to the
@@ -119,12 +117,14 @@ module MiniMagick
       imagemagick7:   "magick",
     }
 
+    # @private (for backwards compatibility)
     def processor
       @processor ||= CLI_DETECTION.values.detect do |processor|
         MiniMagick::Utilities.which(processor)
       end
     end
 
+    # @private (for backwards compatibility)
     def processor=(processor)
       @processor = processor.to_s
 

--- a/lib/mini_magick/configuration.rb
+++ b/lib/mini_magick/configuration.rb
@@ -171,7 +171,13 @@ module MiniMagick
     # @return [String]
     #
     def cli_path
-      @cli_path || @processor_path
+      if instance_variable_defined?("@cli_path")
+        instance_variable_get("@cli_path")
+      else
+        processor_path = instance_variable_get("@processor_path")
+
+        instance_variable_set("@cli_path", processor_path)
+      end
     end
 
     ##

--- a/lib/mini_magick/configuration.rb
+++ b/lib/mini_magick/configuration.rb
@@ -135,11 +135,21 @@ module MiniMagick
       end
     end
 
+    ##
+    # Get [ImageMagick](http://www.imagemagick.org) or
+    # [GraphicsMagick](http://www.graphicsmagick.org).
+    #
+    # @return [Symbol] `:imagemagick` or `:graphicsmagick`
+    #
     def cli
       @cli || CLI_DETECTION.key(processor) or
         fail MiniMagick::Error, "You must have ImageMagick or GraphicsMagick installed"
     end
 
+    ##
+    # Set whether you want to use [ImageMagick](http://www.imagemagick.org) or
+    # [GraphicsMagick](http://www.graphicsmagick.org).
+    #
     def cli=(value)
       @cli = value
 

--- a/lib/mini_magick/configuration.rb
+++ b/lib/mini_magick/configuration.rb
@@ -140,8 +140,14 @@ module MiniMagick
     # @return [Symbol] `:imagemagick` or `:graphicsmagick`
     #
     def cli
-      @cli || CLI_DETECTION.key(processor) or
-        fail MiniMagick::Error, "You must have ImageMagick or GraphicsMagick installed"
+      if instance_variable_defined?("@cli")
+        instance_variable_get("@cli")
+      else
+        cli = CLI_DETECTION.key(processor) or
+          fail MiniMagick::Error, "You must have ImageMagick or GraphicsMagick installed"
+
+        instance_variable_set("@cli", cli)
+      end
     end
 
     ##

--- a/lib/mini_magick/configuration.rb
+++ b/lib/mini_magick/configuration.rb
@@ -174,7 +174,7 @@ module MiniMagick
       if instance_variable_defined?("@cli_path")
         instance_variable_get("@cli_path")
       else
-        processor_path = instance_variable_get("@processor_path")
+        processor_path = instance_variable_get("@processor_path") if instance_variable_defined?("@processor_path")
 
         instance_variable_set("@cli_path", processor_path)
       end

--- a/lib/mini_magick/configuration.rb
+++ b/lib/mini_magick/configuration.rb
@@ -16,9 +16,7 @@ module MiniMagick
     # If you don't have the CLI tools in your PATH, you can set the path to the
     # executables.
     #
-    # @return [String]
-    #
-    attr_accessor :cli_path
+    attr_writer :cli_path
     # @private (for backwards compatibility)
     attr_accessor :processor_path
 
@@ -160,6 +158,12 @@ module MiniMagick
       end
     end
 
+    ##
+    # If you set the path of CLI tools, you can get the path of the
+    # executables.
+    #
+    # @return [String]
+    #
     def cli_path
       @cli_path || @processor_path
     end

--- a/lib/mini_magick/image/info.rb
+++ b/lib/mini_magick/image/info.rb
@@ -141,7 +141,7 @@ module MiniMagick
             end
 
             key, _, value = line.partition(/:[\s]/).map(&:strip)
-            hash = key_stack.inject(details_hash) { |h, k| h.fetch(k) }
+            hash = key_stack.inject(details_hash) { |_hash, _key| _hash.fetch(_key) }
             if value.empty?
               hash[key] = {}
               key_stack.push key


### PR DESCRIPTION
This PR suppresses the following Ruby warnings in production codes.

- ⚠️ `shadowing outer local variable - hash`
- ⚠️ `shadowing outer local variable - key`
- ⚠️ `character class has duplicated range: /:[\s\n]/`
- ⚠️ `method redefined; discarding old processor`
- ⚠️ `method redefined; discarding old processor=`
- ⚠️ `method redefined; discarding old cli`
- ⚠️ `method redefined; discarding old cli=`
- ⚠️ `method redefined; discarding old cli_path`
- ⚠️ `method redefined; discarding old debug=`
- ⚠️ `instance variable @cli not initialized`
- ⚠️ `instance variable @cli_path not initialized`
- ⚠️ `instance variable @processor_path not initialized`

Some warnings are summarized in one commit.
