### PR TITLE
Use POSIX::Spawn::Child to avoid deadlocks due to pipe hangs

### DIFF
--- a/lib/mini_magick/shell.rb
+++ b/lib/mini_magick/shell.rb
@@ -45,11 +45,10 @@ module MiniMagick
 
     def execute_posix_spawn(command, options = {})
       require "posix-spawn"
-
-      pid, in_w, out_r, err_r = POSIX::Spawn.popen4(*command)
-      subprocess_thread = Process.detach(pid)
-
-      capture_command(in_w, out_r, err_r, subprocess_thread, options)
+      child = POSIX::Spawn::Child.new(*command, input: options[:stdin].to_s, timeout: MiniMagick.timeout)
+      [child.out, child.err, child.status]
+    rescue POSIX::Spawn::TimeoutExceeded
+      raise Timeout::Error
     end
 
     def capture_command(in_w, out_r, err_r, subprocess_thread, options)


### PR DESCRIPTION
`POSIX::Spawn.popen4`, like `Open3.popen3`, is susceptible to deadlock when one of the pipes it uses to capture the subprocess’s `stdout` and `stderr` streams fills up.

For example, assume the fixed-size buffer backing `stderr` reaches capacity: the child process will hang when it next attempts to write to `stderr`. If the parent process attempts to consume `stdout`, it will block until the child process writes to `stdout`, which will never happen.

`MiniMagick::Shell#capture_command` attempts to avoid deadlock by reading from the `stdout` and `stderr` pipes created by `popen4` in separate threads. Unfortunately, we’ve observed deadlocks in production on a regular basis (dozens of times a day at most). I imagine Ruby isn’t switching between the reader threads fast enough to keep both pipes’ buffers from filling up, but I don’t know enough about Ruby internals to point a finger at that with any certainty.

`POSIX::Spawn::Child` successfully avoids deadlock by reading fixed-size chunks from `stdout` and `stderr` in a loop. We’ve run this branch of MiniMagick in production for a few days and observed no deadlocks.

/cc @jeremy