### PR TITLE
Add cli_prefix option to configure a prefix for the CLI command

### DIFF
--- a/lib/mini_magick/configuration.rb
+++ b/lib/mini_magick/configuration.rb
@@ -25,6 +25,17 @@ module MiniMagick
     attr_accessor :processor_path
 
     ##
+    # Adds a prefix to the CLI command.
+    # For example, you could use `firejail` to run all commands in a sandbox.
+    # Can be a string, or an array of strings.
+    # e.g. 'firejail', or ['firejail', '--force']
+    #
+    # @return [String]
+    # @return [Array<String>]
+    #
+    attr_accessor :cli_prefix
+
+    ##
     # If you don't want commands to take too long, you can set a timeout (in
     # seconds).
     #

--- a/lib/mini_magick/tool.rb
+++ b/lib/mini_magick/tool.rb
@@ -110,7 +110,8 @@ module MiniMagick
 
     ##
     # The executable used for this tool. Respects
-    # {MiniMagick::Configuration#cli} and {MiniMagick::Configuration#cli_path}.
+    # {MiniMagick::Configuration#cli}, {MiniMagick::Configuration#cli_path},
+    # and {MiniMagick::Configuration#cli_prefix}.
     #
     # @return [Array<String>]
     #
@@ -119,10 +120,21 @@ module MiniMagick
     #   identify = MiniMagick::Tool::Identify.new
     #   identify.executable #=> ["gm", "identify"]
     #
+    # @example
+    #   MiniMagick.configure do |config|
+    #     config.cli = :graphicsmagick
+    #     config.cli_prefix = ['firejail', '--force']
+    #   end
+    #   identify = MiniMagick::Tool::Identify.new
+    #   identify.executable #=> ["firejail", "--force", "gm", "identify"]
+    #
     def executable
       exe = [name]
       exe.unshift "gm" if MiniMagick.graphicsmagick?
       exe.unshift File.join(MiniMagick.cli_path, exe.shift) if MiniMagick.cli_path
+      if MiniMagick.cli_prefix
+        Array(MiniMagick.cli_prefix).reverse.each { |p| exe.unshift p }
+      end
       exe
     end
 

--- a/spec/lib/mini_magick/configuration_spec.rb
+++ b/spec/lib/mini_magick/configuration_spec.rb
@@ -39,6 +39,13 @@ RSpec.describe MiniMagick::Configuration do
     end
   end
 
+  describe "#cli_prefix" do
+    it "can be assigned" do
+      subject.cli_prefix = 'firejail'
+      expect(subject.cli_prefix).to eq 'firejail'
+    end
+  end
+
   describe "#processor" do
     it "assigns :mogrify by default" do
       expect(subject.processor).to eq "mogrify"

--- a/spec/lib/mini_magick/tool_spec.rb
+++ b/spec/lib/mini_magick/tool_spec.rb
@@ -61,6 +61,18 @@ RSpec.describe MiniMagick::Tool do
       allow(MiniMagick).to receive(:cli_path).and_return("path/to/cli")
       expect(subject.executable).to eq %W[path/to/cli/identify]
     end
+
+    it "respects #cli_prefix as a string" do
+      allow(MiniMagick).to receive(:cli).and_return(:imagemagick)
+      allow(MiniMagick).to receive(:cli_prefix).and_return('firejail')
+      expect(subject.executable).to eq %W[firejail identify]
+    end
+
+    it "respects #cli_prefix as an array" do
+      allow(MiniMagick).to receive(:cli).and_return(:imagemagick)
+      allow(MiniMagick).to receive(:cli_prefix).and_return(['firejail', '--force'])
+      expect(subject.executable).to eq %W[firejail --force identify]
+    end
   end
 
   describe "#<<" do


### PR DESCRIPTION
Adds support for running commands in a sandbox, using [firejail](https://github.com/netblue30/firejail) or [mbox](https://github.com/tsgates/mbox).

See: #448