### PR TITLE
Fix test: Use smallcase for MiniMagick::Image#details

### DIFF
--- a/spec/lib/mini_magick/image_spec.rb
+++ b/spec/lib/mini_magick/image_spec.rb
@@ -420,7 +420,7 @@ require "webmock/rspec"
         it "returns a hash of verbose information" do
           expect(subject.details["Format"]).to match /^JPEG/
           if MiniMagick.cli == :imagemagick
-            expect(subject.details["Channel depth"]["Red"]).to eq "8-bit"
+            expect(subject.details["Channel depth"]["red"]).to eq "8-bit"
             expect(subject.details).to have_key("Background color")
             expect(subject.details["Properties"]).to have_key("date:create")
           else


### PR DESCRIPTION
`MiniMagick::Image#details` has been deprecated, as it was causing too many parsing errors. You should use MiniMagick::Image#data instead, which differs in a way that the keys are in camelcase.