### PR TITLE
Fix test: match new `identify` error message

### DIFF
--- a/spec/lib/mini_magick/shell_spec.rb
+++ b/spec/lib/mini_magick/shell_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe MiniMagick::Shell do
           stdout, stderr, status = subject.execute(%W[identify foo])
 
           expect(stdout).to eq ""
-          expect(stderr).to match("unable to open image 'foo'")
+          expect(stderr).to match(/identify: unable to open image `foo': No such file or directory/)
           expect(status).to eq 1
         end
 


### PR DESCRIPTION
[identify](https://linux.die.net/man/1/identify) changed output.