### PR TITLE
Avoid 2.5+ warnings

### DIFF
--- a/lib/mini_magick/image/info.rb
+++ b/lib/mini_magick/image/info.rb
@@ -140,8 +140,8 @@ module MiniMagick
               next
             end
 
-            key, _, value = line.partition(/:[\s\n]/).map(&:strip)
-            hash = key_stack.inject(details_hash) { |hash, key| hash.fetch(key) }
+            key, _, value = line.partition(/:[\s]/).map(&:strip)
+            hash = key_stack.inject(details_hash) { |h, k| h.fetch(k) }
             if value.empty?
               hash[key] = {}
               key_stack.push key


### PR DESCRIPTION
Fixes
```
$ ruby -cw lib/mini_magick/image/info.rb
lib/mini_magick/image/info.rb:143: warning: character class has duplicated range: /:[\s\n]/
lib/mini_magick/image/info.rb:144: warning: shadowing outer local variable - hash
lib/mini_magick/image/info.rb:144: warning: shadowing outer local variable - key
Syntax OK
```

You can also see the warnings on [Rails CI](https://travis-ci.org/rails/rails/jobs/395634343#L1411-L1413)

Related #422