### PR TITLE
Specify and update IM 6 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ rvm:
   - jruby
   - ruby-head
 env:
-  - IM_VERSION=7
-  - IM_VERSION=6
+  - IM_VERSION=7.0.8-11
+  - IM_VERSION=6.9.10-11
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/install/imagemagick.sh
+++ b/install/imagemagick.sh
@@ -1,14 +1,7 @@
 set -e
 
-case "$IM_VERSION" in
-  6)
-    sudo apt-get install imagemagick libmagickcore-dev libmagickwand-dev
-    ;;
-  7)
-    curl -O "http://www.imagemagick.org/download/ImageMagick.tar.gz"
-    tar xzf "ImageMagick.tar.gz"
-    cd ImageMagick-7*
-    ./configure --prefix=/usr
-    sudo make install
-    ;;
-esac
+curl -O "http://www.imagemagick.org/download/ImageMagick-$IM_VERSION.tar.gz"
+tar xzf "ImageMagick-$IM_VERSION.tar.gz"
+cd ImageMagick-*
+./configure --prefix=/usr
+sudo make install


### PR DESCRIPTION
Currently, IM 6.7.7-10 is used on travis:
https://travis-ci.org/minimagick/minimagick/jobs/428581432

seems updating imagemagick to 6.9 fix builds except jruby

https://travis-ci.org/mtsmfm/minimagick/builds/428888357