### PR TITLE
[Don't merge] Increase sleep time to fix test for JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ rvm:
   - jruby
   - ruby-head
 env:
-  - IM_VERSION=7
-  - IM_VERSION=6
+  - IM_VERSION=7.0.8-11
+  - IM_VERSION=6.9.10-11
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/install/imagemagick.sh
+++ b/install/imagemagick.sh
@@ -1,14 +1,7 @@
 set -e
 
-case "$IM_VERSION" in
-  6)
-    sudo apt-get install imagemagick libmagickcore-dev libmagickwand-dev
-    ;;
-  7)
-    curl -O "http://www.imagemagick.org/download/ImageMagick.tar.gz"
-    tar xzf "ImageMagick.tar.gz"
-    cd ImageMagick-7*
-    ./configure --prefix=/usr
-    sudo make install
-    ;;
-esac
+curl -O "http://www.imagemagick.org/download/ImageMagick-$IM_VERSION.tar.gz"
+tar xzf "ImageMagick-$IM_VERSION.tar.gz"
+cd ImageMagick-*
+./configure --prefix=/usr
+sudo make install

--- a/spec/lib/mini_magick/shell_spec.rb
+++ b/spec/lib/mini_magick/shell_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe MiniMagick::Shell do
 
         it "terminate long running commands if MiniMagick.timeout is set" do
           MiniMagick.timeout = 0.1
-          expect { subject.execute(%w[sleep 0.2]) }.to raise_error(Timeout::Error)
+          expect { subject.execute(%w[sleep 1]) }.to raise_error(Timeout::Error)
           MiniMagick.timeout = nil
         end
 


### PR DESCRIPTION
To make sure CI is fixed via these two PRs, this PR depends on https://github.com/minimagick/minimagick/pull/464.
Please review and merge https://github.com/minimagick/minimagick/pull/464 first 🙏 

---------

For some reason, the following code will take 0.2 sec on JRuby.

```ruby
require 'timeout'
require 'open3'
before = Time.now

_, _, _, subprocess_thread = Open3.popen3(*%w[sleep 1])
begin
  Timeout.timeout(0.1) { subprocess_thread.join }
  rescue Timeout::Error
  end

  p Time.now - before

# JRuby #=> 0.264936
# CRuby #=> 0.1025682
```

It means a thread runs `sleep` is already finished when MiniMagick kills the process in
https://github.com/minimagick/minimagick/blob/1997088636c0dada0f17f10477aec80727f0cb5e/lib/mini_magick/shell.rb#L68