### PR TITLE
Fix download script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ rvm:
   - jruby
   - ruby-head
 env:
-  - IM_VERSION=7.0.8-11
-  - IM_VERSION=6.9.10-11
+  - IM_VERSION=7.0.8
+  - IM_VERSION=6.9.10
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/install/imagemagick.sh
+++ b/install/imagemagick.sh
@@ -1,7 +1,8 @@
-set -e
+set -ex
 
-curl -O "http://www.imagemagick.org/download/ImageMagick-$IM_VERSION.tar.gz"
-tar xzf "ImageMagick-$IM_VERSION.tar.gz"
+im_download_path=$(curl -sf http://www.imagemagick.org/download/releases/ | grep -o "ImageMagick-$IM_VERSION-.*.tar.gz" -m 1)
+curl -f "http://www.imagemagick.org/download/releases/$im_download_path" > ImageMagick.tar.gz
+tar xzf ImageMagick.tar.gz
 cd ImageMagick-*
 ./configure --prefix=/usr
 sudo make install


### PR DESCRIPTION
ref: https://github.com/minimagick/minimagick/pull/464

It seems older releases are removed from http://www.imagemagick.org/download/

I thought every version (x.y.z-n) is available on somewhere but I can't
find the page.

According to the following page, every x.y.z-10 should be available but
6.9.10-10 and 7.0.8-10 are not listed.

https://www.imagemagick.org/discourse-server/viewtopic.php?t=12212

So I changed install script to find exact download path.

cc @koic 