### PR TITLE
Test with Ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
   - jruby
   - ruby-head
 env:


### PR DESCRIPTION
Ruby 2.6.0 has been released on 2018-12-25. Please add Ruby 2.6 to .travis.yml.
https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/