### PR TITLE
Fix Ruby 2.7 warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 cache: bundler
 rvm:
-  - 1.9.3
   - 2.0
   - 2.1
   - 2.2

--- a/lib/mini_magick/image.rb
+++ b/lib/mini_magick/image.rb
@@ -102,7 +102,11 @@ module MiniMagick
       end
       ext.sub!(/:.*/, '') # hack for filenames or URLs that include a colon
 
-      openable.open(options) { |file| read(file, ext) }
+      if openable.is_a?(URI::Generic) || RUBY_VERSION < "2.0"
+        openable.open(options) { |file| read(file, ext) }
+      else
+        openable.open(**options) { |file| read(file, ext) }
+      end
     end
 
     ##

--- a/lib/mini_magick/image.rb
+++ b/lib/mini_magick/image.rb
@@ -102,7 +102,7 @@ module MiniMagick
       end
       ext.sub!(/:.*/, '') # hack for filenames or URLs that include a colon
 
-      if openable.is_a?(URI::Generic) || RUBY_VERSION < "2.0"
+      if openable.is_a?(URI::Generic)
         openable.open(options) { |file| read(file, ext) }
       else
         openable.open(**options) { |file| read(file, ext) }

--- a/mini_magick.gemspec
+++ b/mini_magick.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |s|
   s.files        = Dir['README.rdoc', 'VERSION', 'MIT-LICENSE', 'Rakefile', 'lib/**/*']
   s.require_paths = ['lib']
 
+  s.required_ruby_version = '>= 2.0'
+
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 3.5.0'
   s.add_development_dependency 'guard'


### PR DESCRIPTION
Rails CI with Ruby master has broken by https://github.com/ruby/ruby/pull/2794.

https://buildkite.com/rails/rails/builds/66163#c6c0c423-bb9b-4c20-bab4-8a6aa56c726d/936-1235
https://github.com/rails/rails/blob/5a010d8537afa957f1a6c7ec0d9f4d66ef5ae5e1/activestorage/test/test_helper.rb#L94

To fix the CI failure, fixing kwargs deprecation warnings is required.