### PR TITLE
Suppress warnings

### DIFF
--- a/lib/mini_magick/configuration.rb
+++ b/lib/mini_magick/configuration.rb
@@ -5,14 +5,6 @@ module MiniMagick
   module Configuration
 
     ##
-    # Set whether you want to use [ImageMagick](http://www.imagemagick.org) or
-    # [GraphicsMagick](http://www.graphicsmagick.org).
-    #
-    # @return [Symbol] `:imagemagick`, `:imagemagick7`, or `:graphicsmagick`
-    #
-    attr_accessor :cli
-
-    ##
     # If you don't have the CLI tools in your PATH, you can set the path to the
     # executables.
     #


### PR DESCRIPTION
This pull-request makes no warnings.

Before pull-request: 2 warnings.

```
yuya@yoshiyuki|2:01:27|0% ruby -w -Ilib -rmini_magick -e ''
/home/yuya/src/github.com/minimagick/minimagick/lib/mini_magick/configuration.rb:142: warning: method redefined; discarding old cli
/home/yuya/src/github.com/minimagick/minimagick/lib/mini_magick/configuration.rb:157: warning: method redefined; discarding old cli=
```

After pull-request: no warnings.

```
yuya@yoshiyuki|2:01:48|0% ruby -w -Ilib -rmini_magick -e ''
```

Related old issues and pull-requests:

* https://github.com/minimagick/minimagick/pull/427 https://github.com/minimagick/minimagick/pull/427/commits/2965e55c78e590284a676ab79e67f7185aa4a688
* https://github.com/minimagick/minimagick/issues/422
