### PR TITLE
Fix Imagemagick download URI on CI

### DIFF
--- a/install/imagemagick.sh
+++ b/install/imagemagick.sh
@@ -1,7 +1,7 @@
 set -ex
 
-im_download_path=$(curl -sf http://www.imagemagick.org/download/releases/ | grep -o "ImageMagick-$IM_VERSION-.*.tar.xz" -m 1)
-curl -f "http://www.imagemagick.org/download/releases/$im_download_path" > ImageMagick.tar.xz
+im_download_path=$(curl -sf https://www.imagemagick.org/download/releases/ | grep -o "ImageMagick-$IM_VERSION-.*.tar.xz" -m 1)
+curl -f "https://www.imagemagick.org/download/releases/$im_download_path" > ImageMagick.tar.xz
 tar xf ImageMagick.tar.xz
 cd ImageMagick-*
 ./configure --prefix=/usr

--- a/install/imagemagick.sh
+++ b/install/imagemagick.sh
@@ -1,8 +1,8 @@
 set -ex
 
-im_download_path=$(curl -sf http://www.imagemagick.org/download/releases/ | grep -o "ImageMagick-$IM_VERSION-.*.tar.gz" -m 1)
-curl -f "http://www.imagemagick.org/download/releases/$im_download_path" > ImageMagick.tar.gz
-tar xzf ImageMagick.tar.gz
+im_download_path=$(curl -sf http://www.imagemagick.org/download/releases/ | grep -o "ImageMagick-$IM_VERSION-.*.tar.xz" -m 1)
+curl -f "http://www.imagemagick.org/download/releases/$im_download_path" > ImageMagick.tar.xz
+tar xf ImageMagick.tar.xz
 cd ImageMagick-*
 ./configure --prefix=/usr
 sudo make install


### PR DESCRIPTION
This pull-request uses XZ archive instead of Gzip on CI.

http://www.imagemagick.org/download/releases/ImageMagick-6.9.10-33.tar.gz is 404 Not Found:  https://travis-ci.org/github/minimagick/minimagick/jobs/661176777

But, https://www.imagemagick.org/download/releases/ImageMagick-6.9.10-33.tar.xz is alive. So this pull-request uses XZ.

And use HTTPS for downloading.
