### PR TITLE
Remove Ruby 1.9.3 from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ MiniMagick has been tested on following Rubies:
 * MRI 2.2
 * MRI 2.1
 * MRI 2.0
-* MRI 1.9.3
 * JRuby 9k
 
 ## Installation


### PR DESCRIPTION
As it was dropped in 1b3fe5928aeb92a4ddade9f89db4ba610ebbef82 (#496)