### PR TITLE
Parse out Ghostscript warnings in identfication

### DIFF
--- a/lib/mini_magick/image/info.rb
+++ b/lib/mini_magick/image/info.rb
@@ -42,7 +42,7 @@ module MiniMagick
 
       def cheap_info(value)
         @info.fetch(value) do
-          format, width, height, size = self["%m %w %h %b"].split(" ")
+          format, width, height, size = parse_warnings(self["%m %w %h %b"]).split(" ")
 
           path = @path
           path = path.match(/\[\d+\]$/).pre_match if path =~ /\[\d+\]$/
@@ -60,6 +60,16 @@ module MiniMagick
         end
       rescue ArgumentError, TypeError
         raise MiniMagick::Invalid, "image data can't be read"
+      end
+            
+      def parse_warnings(raw_info)
+        return raw_info unless raw_info.split("\n").size > 1
+
+        raw_info.split("\n").each do |line|
+          # must match "%m %w %h %b"
+          return line if line.match? /^[A-Z]+ \d+ \d+ \d+B$/
+        end
+        raise TypeError
       end
 
       def colorspace


### PR DESCRIPTION
This bug is partly identified by this [Ghostscript thread](https://bugs.ghostscript.com/show_bug.cgi?format=multiple&id=701772), which details that GS may additionally output warning messages when `identify` is run on the associated file. This results in parsing errors, as the output is now multi-line and the file's attributes are read.

The following occurs when MiniMagick attempts to access those attributes:
```bash
# using the attached file from the original Ghostscript thread
wget https://bugs.ghostscript.com/attachment.cgi?id=18348 -O attachment.pdf
```

```ruby
1:(main)> t = MiniMagick::Image.open("attachment.pdf")
=> #<MiniMagick::Image:0x000000000c63b918 ... >
2:(main)> t.dimensions
MiniMagick::Invalid: image data can't be read
from <omitted>/mini_magick.rb:37:in `rescue in cheap_info'
Caused by ArgumentError: invalid value for Integer(): "Error:"
from <omitted>/mini_magick.rb:27:in `Integer'
3:(main)> t.info("raw: %m %w %h %b")
=> "   **** Error: stream operator isn't terminated by valid EOL.\n               Output may be incorrect.\n   **** Error: stream operator isn't terminated by valid EOL.\n               Output may be incorrect.\nPDF 596 842 63214B"
```

The fix is to identify if the warning messages appear, and if so, match
the attributes via strict regular expression.

```ruby
t = MiniMagick::Image.open("attachment.pdf")
=> #<MiniMagick::Image:0x000000000ce25f98 ... >
2:(main)> t.dimensions
=> [596, 842]
```
