### PR TITLE
Simpler command timeout

### DIFF
--- a/lib/mini_magick/shell.rb
+++ b/lib/mini_magick/shell.rb
@@ -50,9 +50,7 @@ module MiniMagick
         end
         in_w.close
 
-        begin
-          Timeout.timeout(MiniMagick.timeout) { thread.join }
-        rescue Timeout::Error
+        unless thread.join(MiniMagick.timeout)
           Process.kill("TERM", thread.pid) rescue nil
           Process.waitpid(thread.pid)      rescue nil
           raise Timeout::Error, "MiniMagick command timed out: #{command}"


### PR DESCRIPTION
[`Thread#join`](https://ruby-doc.org/core-2.5.0/Thread.html#method-i-join) takes a `timeout` argument, and returns `nil` if the thread hasn't completed in that given time.

It's simpler, cheaper and more reliable than `Timeout.timeout`.