### PR TITLE
Add configuration to change temporary directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,20 @@ setting the following variables in your application's process environment:
 For a full list of variables and description, see [ImageMagick's resources
 documentation](http://www.imagemagick.org/script/resources.php#environment).
 
+## Changing temporary directory
+
+ImageMagick allows you to change the temporary directory to process the image file:
+
+```rb
+MiniMagick.configure do |config|
+  config.tmpdir = File.join(Dir.tmpdir, "/my/new/tmp_dir")
+end
+```
+
+The example directory `/my/new/tmp_dir` must exist and must be writable.
+
+If not configured, it will default to `Dir.tmpdir`.
+
 ## Troubleshooting
 
 ### Errors being raised when they shouldn't

--- a/lib/mini_magick/configuration.rb
+++ b/lib/mini_magick/configuration.rb
@@ -45,6 +45,13 @@ module MiniMagick
     # @return [Logger]
     #
     attr_accessor :logger
+    ##
+    # Temporary directory used by MiniMagick, default is `Dir.tmpdir`, but
+    # you can override it.
+    #
+    # @return [String]
+    #
+    attr_accessor :tmpdir
 
     ##
     # If set to `true`, it will `identify` every newly created image, and raise
@@ -82,6 +89,7 @@ module MiniMagick
     attr_accessor :shell_api
 
     def self.extended(base)
+      base.tmpdir = Dir.tmpdir
       base.validate_on_create = true
       base.validate_on_write = true
       base.whiny = true

--- a/lib/mini_magick/utilities.rb
+++ b/lib/mini_magick/utilities.rb
@@ -24,7 +24,7 @@ module MiniMagick
     end
 
     def tempfile(extension)
-      Tempfile.new(["mini_magick", extension]).tap do |tempfile|
+      Tempfile.new(["mini_magick", extension], MiniMagick.tmpdir).tap do |tempfile|
         tempfile.binmode
         yield tempfile if block_given?
         tempfile.close

--- a/spec/lib/mini_magick/image_spec.rb
+++ b/spec/lib/mini_magick/image_spec.rb
@@ -138,6 +138,19 @@ require "webmock/rspec"
           expect { create(image_path(:not)) }
             .not_to raise_error
         end
+
+        context "when a tmpdir is configured" do
+          before { FileUtils.mkdir_p(new_tmp_dir) }
+          after { FileUtils.rm_rf(new_tmp_dir) }
+
+          let(:new_tmp_dir) { File.join(Dir.tmpdir, "new_tmp_dir") }
+
+          it "uses the tmpdir to create the file" do
+            allow(MiniMagick).to receive(:tmpdir).and_return(new_tmp_dir)
+            image = create
+            expect(File.dirname(image.path)).to eq new_tmp_dir
+          end
+        end
       end
 
       describe "#initialize" do


### PR DESCRIPTION
Add configuration to change temporary directory.

Example:
```ruby
MiniMagick.configure do |config|
  config.tmpdir = File.join(Dir.tmpdir, "/my/new/tmp_dir")
end
```
Defaults to `Dir.tmpdir`.