### PR TITLE
Add cmd status to exception

### DIFF
--- a/lib/mini_magick/shell.rb
+++ b/lib/mini_magick/shell.rb
@@ -14,7 +14,7 @@ module MiniMagick
       stdout, stderr, status = execute(command, stdin: options[:stdin])
 
       if status != 0 && options.fetch(:whiny, MiniMagick.whiny)
-        fail MiniMagick::Error, "`#{command.join(" ")}` failed with error:\n#{stderr}"
+        fail MiniMagick::Error, "`#{command.join(" ")}` failed with status: #{status} and error:\n#{stderr}"
       end
 
       $stderr.print(stderr) unless options[:stderr] == false

--- a/spec/lib/mini_magick/shell_spec.rb
+++ b/spec/lib/mini_magick/shell_spec.rb
@@ -15,10 +15,13 @@ RSpec.describe MiniMagick::Shell do
       expect(output).to eq ["stdout", "stderr", 0]
     end
 
-    it "uses stderr for error messages" do
+    it "uses stderr and status for error messages" do
       allow(subject).to receive(:execute).and_return(["", "stderr", 1])
+
+      expected_msg = "`foo` failed with status: 1 and error:\nstderr"
+
       expect { subject.run(%W[foo]) }
-        .to raise_error(MiniMagick::Error, /`foo`.*stderr/m)
+        .to raise_error(MiniMagick::Error, expected_msg)
     end
 
     it "raises an error when executable wasn't found" do


### PR DESCRIPTION
For some reasons, stderr is blank. See https://github.com/minimagick/minimagick/issues/471 
This PR adds status to exception for more informative errors, It may help to understand the reason why cmd fails.