### PR TITLE
Implement thread-safe Open3 integration using IO::select

### DIFF
--- a/lib/mini_magick/shell.rb
+++ b/lib/mini_magick/shell.rb
@@ -35,28 +35,62 @@ module MiniMagick
 
     private
 
+    class P_FinishWrite < ::StandardError
+    end
+
+    P_ChunkSize = 1024 * 32
+
+    private_constant :P_FinishWrite, :P_ChunkSize
+
     def execute_open3(command, options = {})
       require "open3"
-
       # We would ideally use Open3.capture3, but it wouldn't allow us to
       # terminate the command after timing out.
-      Open3.popen3(*command) do |in_w, out_r, err_r, thread|
-        [in_w, out_r, err_r].each(&:binmode)
-        stdout_reader = Thread.new { out_r.read }
-        stderr_reader = Thread.new { err_r.read }
-        begin
-          in_w.write options[:stdin].to_s
-        rescue Errno::EPIPE
-        end
-        in_w.close
 
-        unless thread.join(MiniMagick.timeout)
-          Process.kill("TERM", thread.pid) rescue nil
-          Process.waitpid(thread.pid)      rescue nil
-          raise Timeout::Error, "MiniMagick command timed out: #{command}"
+      out_buffer, err_buffer = [::StringIO.new, ::StringIO.new]
+      start_time = ::Time.now
+      applied_timeout = MiniMagick.timeout || 3_600
+      ::Open3.popen3(*command) do |in_w, out_r, err_r, thread|
+        [in_w, out_r, err_r, out_buffer, err_buffer].each(&:binmode)
+        read_wait, write_wait = [[out_r, err_r], [in_w]]
+        stdin_buffer = options[:stdin].to_s
+        if stdin_buffer.empty?
+          in_w.close
+          write_wait.delete(in_w)
         end
-
-        [stdout_reader.value, stderr_reader.value, thread.value]
+        until read_wait.empty? && write_wait.empty? do
+          current_time = ::Time.now
+          elapse = current_time - start_time
+          remaining = applied_timeout - elapse
+          raise Timeout::Error, "MiniMagick command timed out: #{command}" unless 0 < remaining
+          readable, writable = ::IO.select(read_wait, write_wait, read_wait + write_wait, remaining)
+          writable&.each do |io|
+            # assume io == in_w
+            byte_written = io.write_nonblock stdin_buffer
+            stdin_buffer = begin
+              stdin_buffer.byteslice(byte_written..-1)
+            rescue ::NoMethodError
+              stdin_buffer.slice(byte_written..-1)
+            end
+            raise P_FinishWrite unless 0 < stdin_buffer.bytesize
+          rescue ::Errno::EAGAIN, ::Errno::EINTR
+            next
+          rescue ::Errno::EPIPE, P_FinishWrite
+            io.close
+            write_wait.delete(io)
+          end
+          readable&.each do |io|
+            buffer = io.read_nonblock(P_ChunkSize)
+            out_buffer << buffer if io == out_r
+            err_buffer << buffer if io == err_r
+          rescue ::Errno::EAGAIN, ::Errno::EINTR
+            next
+          rescue ::EOFError
+            io.close
+            read_wait.delete(io)
+          end
+        end
+        [out_buffer.string, err_buffer.string, thread.value]
       end
     end
 

--- a/lib/mini_magick/shell.rb
+++ b/lib/mini_magick/shell.rb
@@ -91,6 +91,14 @@ module MiniMagick
           end
         end
         [out_buffer.string, err_buffer.string, thread.value]
+      rescue ::Object => e
+        # clean up
+        [in_w, out_r, err_r].each do |io|
+          io.close rescue nil
+        end
+        ::Process.kill('TERM', thread.pid) rescue nil
+        ::Process.waitpid(thread.pid) rescue nil
+        raise e
       end
     end
 


### PR DESCRIPTION
Please refer to #437; I wonder why the equivalent `IO::select` doesn't get ported to `Open3`.
It doesn't look too complicated.