### PR TITLE
Fix handling of tempfile in `MiniMagick::Image#format`

### DIFF
--- a/lib/mini_magick/image.rb
+++ b/lib/mini_magick/image.rb
@@ -461,6 +461,9 @@ module MiniMagick
       @info.clear
 
       self
+    rescue MiniMagick::Invalid, MiniMagick::Error => e
+      new_tempfile.unlink
+      raise e
     end
 
     ##

--- a/lib/mini_magick/image.rb
+++ b/lib/mini_magick/image.rb
@@ -462,7 +462,7 @@ module MiniMagick
 
       self
     rescue MiniMagick::Invalid, MiniMagick::Error => e
-      new_tempfile.unlink
+      new_tempfile.unlink if new_tempfile && @tempfile != new_tempfile
       raise e
     end
 

--- a/spec/lib/mini_magick/image_spec.rb
+++ b/spec/lib/mini_magick/image_spec.rb
@@ -306,7 +306,17 @@ require "webmock/rspec"
           layer = subject.layers.first
           layer.format('jpg', nil, {density: '300'})
           expect(layer).to be_valid
+        end
 
+        it "not change tempfile when convert failed" do
+          subject = described_class.create(nil, false) { |f| f.write(File.binread(image_path(:not))) }
+          current_path = subject.path
+          new_tempfile = MiniMagick::Utilities.tempfile('png')
+          new_path = new_tempfile.path
+          allow(MiniMagick::Utilities).to receive(:tempfile).and_return(new_tempfile)
+          expect { begin; subject.format('png'); rescue; end }.not_to change(subject, :tempfile)
+          expect(File.exist?(current_path)).to eq true
+          expect(File.exist?(new_path)).to eq false
         end
       end
 


### PR DESCRIPTION
**Background**

In `MiniMagick::Image#format`, temporary file were left behind when convert failed.

**Solution**

Fixed to delete unnecessary temporary file when convert fails.