### PR TITLE
No longer recommend posix-spawn for Ruby >= 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,7 +558,7 @@ end
 
 ### `Errno::ENOMEM`
 
-It can happen that, when dealing with very large images, the process runs out of
+For clients using Ruby < 2.2, it can happen that, when dealing with very large images, the process runs out of
 memory, and `Errno::ENOMEM` is raised in your code. In that case try installing
 the [posix-spawn](https://github.com/rtomayko/posix-spawn) gem, and tell MiniMagick
 to use it when executing shell commands.


### PR DESCRIPTION
I wanted to kick off a conversation about removing the recommendation to use `posix-spawn` for Ruby > 2.2. 

It's my understanding that `posix-spawn` is not beneficial after Ruby 2.2, https://github.com/luanzeba/progeny/commit/00dac130925b98f2c2e55adb600385a88a8a4d58 summarizes it well, but at a hight level, when posix-spawn is not specified, [minimagick will use Open3](https://github.com/minimagick/minimagick/blob/2a4d0fc5be414017b084628512c38c2ca2f845c5/lib/mini_magick/configuration.rb#L96). Open3 uses [spawn](https://github.com/ruby/open3/blob/b8909222051b4103a19eba19506727faece252e7/lib/open3.rb#L534) internally, which was [updated in Ruby 2.2](https://www.ruby-lang.org/en/news/2014/12/25/ruby-2-2-0-released/).

Additionally, it seems like `posix-spawn` performs worse than native Ruby in 3+:  https://github.com/rtomayko/posix-spawn/issues/90#issuecomment-1140315750.

Last, it looks like `posix-spawn` may no longer be maintained.