### PR TITLE
Save format, dimensions, size, etc when validating to avoid unnecessary second identify call

### DIFF
--- a/lib/mini_magick/image.rb
+++ b/lib/mini_magick/image.rb
@@ -216,7 +216,7 @@ module MiniMagick
     # @raise [MiniMagick::Invalid]
     #
     def validate!
-      identify
+      @info.identify_with_cheap_info
     rescue MiniMagick::Error => error
       raise MiniMagick::Invalid, error.message
     end

--- a/lib/mini_magick/image/info.rb
+++ b/lib/mini_magick/image/info.rb
@@ -184,6 +184,12 @@ module MiniMagick
         end
       end
 
+      def identify_with_cheap_info
+        # asking for any cheap_info value will trigger `identify` to fetch _all_ cheap_info values if necessary
+        # used by Image#validate! to avoid a second `identify` call just to populate cheap_info attributes
+        self['format']
+      end
+
       private
 
       def decode_comma_separated_ascii_characters(encoded_value)

--- a/spec/lib/mini_magick/image_spec.rb
+++ b/spec/lib/mini_magick/image_spec.rb
@@ -109,6 +109,13 @@ require "webmock/rspec"
             .to raise_error(MiniMagick::Invalid)
         end
 
+        it "saves cheap info when validating to avoid an unnecessary second identify call" do
+          expect_any_instance_of(MiniMagick::Tool::Identify).to receive(:call).exactly(:once).and_call_original
+
+          image = described_class.open(image_path)
+          expect(image[:dimensions]).to all(be_a(Integer))
+        end
+
         it "does not mistake a path with a colon for a URI schema" do
           expect { described_class.open(image_path(:colon)) }
             .not_to raise_error


### PR DESCRIPTION
Our application often needs to open an image file and retrieve its dimensions (for storing in our database). 

A typical example looks like this:
```
dimensions = MiniMagick::Image.open(file.path)[:dimensions]
```

I noticed that this line of code actually results in two separate invocations of the `identify` command:
* the first is invoked via `Image#validate!` as a result of `.open` -- any output is ignored, only cares if an exception was raised
* the second is invoked via `[:dimensions]` -- which ultimately runs `identify -format "%m %w %h %b` to fetch/store the `cheap_info` attributes -- format, width, height, dimensions, size, and human_size

If `Image#validate!` acted more like `[:dimensions]` -- parsing the cheap_info attributes and storing them -- then subsequent calls to fetch cheap_info attributes wouldn't need a second `identify` call. 

Is this optimization worth pursuing? In my casual profiling, avoiding the 2nd identify call seems to shave about ~10ms off the "open image and only ask for cheap_info attributes" scenario.

If deemed worth pursuing, I'm happy to polish up this PR -- it's a bit of a hack. There's likely a better way to structure this change, and I welcome any advice (or contributions). 