### PR TITLE
Fix typos in specs, comments, and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ convert.distort("Perspective", "0,0,0,0 0,45,0,45 69,0,60,10 69,45,60,35")
 ```
 
 MiniMagick knows which options each tool has, so you will get an explicit
-`NoMethodError` if you happen to have mispelled an option.
+`NoMethodError` if you happen to have misspelled an option.
 
 #### Chaining
 
@@ -470,7 +470,7 @@ identify.stdin # alias for "-"
 identify.call(stdin: image_content)
 ```
 
-MiniMagick also has `#stdout` alias for "-" for outputing file contents to
+MiniMagick also has `#stdout` alias for "-" for outputting file contents to
 standard output:
 
 ```rb

--- a/lib/mini_magick/configuration.rb
+++ b/lib/mini_magick/configuration.rb
@@ -64,7 +64,7 @@ module MiniMagick
     ##
     # If set to `true`, it will `identify` every image that gets written (with
     # {MiniMagick::Image#write}), and raise `MiniMagick::Invalid` if the image
-    # is not valid. Useful for validating that processing was sucessful,
+    # is not valid. Useful for validating that processing was successful,
     # although it adds a bit of overhead. Defaults to `true`.
     #
     # @return [Boolean]

--- a/lib/mini_magick/image.rb
+++ b/lib/mini_magick/image.rb
@@ -274,7 +274,7 @@ module MiniMagick
     #
     attribute :resolution
     ##
-    # Returns the message digest of this image as a SHA-256, hexidecimal
+    # Returns the message digest of this image as a SHA-256, hexadecimal
     # encoded string. This signature uniquely identifies the image and is
     # convenient for determining if an image has been modified or whether two
     # images are identical.

--- a/spec/lib/mini_magick/tool_spec.rb
+++ b/spec/lib/mini_magick/tool_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe MiniMagick::Tool do
   end
 
   describe "#stack" do
-    it "it surrounds added arguments with parantheses" do
+    it "it surrounds added arguments with parentheses" do
       subject.stack do |stack|
         stack << "foo"
         stack << "bar"
@@ -146,7 +146,7 @@ RSpec.describe MiniMagick::Tool do
       expect(subject.args).to eq %W[-clone 0]
     end
 
-    it "is convertable to plus version" do
+    it "is convertible to plus version" do
       subject.clone.+
       expect(subject.args).to eq %W[+clone]
     end


### PR DESCRIPTION
```
codespell **/*.rb **/*.md -w
```

---

Hello, I was here for minimagick/minimagick@763edb3d45bc76b2fffe2ea47bd2d17ac5cd704a and I took the opportunity to run `codespell` on the codebase