### PR TITLE
Test against Ruby head and improve permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ '**' ]
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -23,6 +26,13 @@ jobs:
           - "3.2"
           - "3.3"
           - "jruby-9.4"
+        channel: ["stable"]
+
+        include:
+          - ruby-version: "ruby-head"
+            channel: "experimental"
+
+    continue-on-error: ${{ matrix.channel != 'stable' }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Run experimental tests against Ruby HEAD to identify errors and deprecation warnings early.

Also add explicit permissions to workflows. Workflows run with extended set of permissions by default. By specifying any permission explicitly, all others are set to none.

Ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions