### PR TITLE
Also add explicit permissions to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ '**' ]
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Workflows run with extended set of permissions by default. By specifying any permission explicitly, all others are set to none.

Ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions