### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/mini_magick

### DIFF
--- a/mini_magick.gemspec
+++ b/mini_magick.gemspec
@@ -24,4 +24,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 3.5.0'
   s.add_development_dependency 'webmock'
+
+  s.metadata['changelog_uri'] = 'https://github.com/minimagick/minimagick/releases'
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/mini_magick which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/