### PR TITLE
Add cli_env option to configure extra env vars for every CLI command

### DIFF
--- a/lib/mini_magick/configuration.rb
+++ b/lib/mini_magick/configuration.rb
@@ -16,6 +16,16 @@ module MiniMagick
     attr_accessor :cli_prefix
 
     ##
+    # Adds environment variables to every CLI command call.
+    # For example, you could use it to set `LD_PRELOAD="/path/to/libsomething.so"`.
+    # Must be a hash of strings keyed to valid environment variable name strings.
+    # e.g. {'MY_ENV' => 'my value'}
+    #
+    # @return [Hash]
+    #
+    attr_accessor :cli_env
+
+    ##
     # If you don't want commands to take too long, you can set a timeout (in
     # seconds).
     #

--- a/lib/mini_magick/shell.rb
+++ b/lib/mini_magick/shell.rb
@@ -27,8 +27,12 @@ module MiniMagick
     end
 
     def execute(command, stdin: "", timeout: MiniMagick.timeout)
+      env = {}
+      env.merge!(MiniMagick.cli_env) if MiniMagick.cli_env.is_a?(Hash)
+      env["MAGICK_TIME_LIMIT"] = timeout&.to_s
+
       stdout, stderr, status = log(command.join(" ")) do
-        Open3.capture3({ "MAGICK_TIME_LIMIT" => timeout&.to_s }, *command, stdin_data: stdin)
+        Open3.capture3(env, *command, stdin_data: stdin)
       end
 
       [stdout, stderr, status&.exitstatus]

--- a/spec/lib/mini_magick/shell_spec.rb
+++ b/spec/lib/mini_magick/shell_spec.rb
@@ -78,5 +78,41 @@ RSpec.describe MiniMagick::Shell do
       stdout, * = subject.execute(["identify", "-format", "%w %h", image_path])
       expect(stdout).to match(/\d+ \d+/)
     end
+
+    it "sets MAGICK_TIME_LIMIT to MiniMagick.timeout or the given timeout" do
+      allow(MiniMagick).to receive(:timeout).and_return(123)
+
+      stdout, stderr, status = subject.execute(%W[env])
+
+      expect(stdout).to match("MAGICK_TIME_LIMIT=123")
+      expect(stderr).to eq ""
+      expect(status).to eq 0
+
+      stdout, stderr, status = subject.execute(%W[env], timeout: 456)
+
+      expect(stdout).to match("MAGICK_TIME_LIMIT=456")
+      expect(stderr).to eq ""
+      expect(status).to eq 0
+    end
+
+    it "executes the command with the environment variables from MiniMagick.cli_env set in the shell" do
+      allow(MiniMagick).to receive(:cli_env).and_return({'MY_ENV' => 'my value'})
+
+      stdout, stderr, status = subject.execute(%W[env])
+
+      expect(stdout).to match("MY_ENV=my value")
+      expect(stderr).to eq ""
+      expect(status).to eq 0
+    end
+
+    it "does not override the timeout if MAGICK_TIME_LIMIT is set in MiniMagick.cli_env" do
+      allow(MiniMagick).to receive(:cli_env).and_return({'MAGICK_TIME_LIMIT' => 'override'})
+
+      stdout, stderr, status = subject.execute(%W[env], timeout: 1)
+
+      expect(stdout).to match("MAGICK_TIME_LIMIT=1")
+      expect(stderr).to eq ""
+      expect(status).to eq 0
+    end
   end
 end


### PR DESCRIPTION
Adds support for setting `LD_PRELOAD` specifically for ImageMagick calls plus any other env a user might want to set for ImageMagick but not the whole system.

See #7882

Thanks =)