### PR TITLE
Add restricted_env option to use Open3 `unsetenv_others:true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ MiniMagick.configure do |config|
   config.logger = Logger.new($stdout) # where to log IM commands
   config.cli_prefix = nil # add prefix to all IM commands
   config.cli_env = {} # environment variables to set for IM commands
+  config.restricted_env = false # allow IM commands to access all system environment variables
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ MiniMagick.configure do |config|
   config.logger = Logger.new($stdout) # where to log IM commands
   config.cli_prefix = nil # add prefix to all IM commands
   config.cli_env = {} # environment variables to set for IM commands
-  config.restricted_env = false # allow IM commands to access all system environment variables
+  config.restricted_env = false # when true, block IM commands from accessing system environment variables other than those in cli_env
 end
 ```
 

--- a/lib/mini_magick/configuration.rb
+++ b/lib/mini_magick/configuration.rb
@@ -33,6 +33,16 @@ module MiniMagick
     attr_accessor :cli_env
 
     ##
+    # If set to true, Open3 will restrict system calls to access only
+    # environment variables defined in :cli_env, plus HOME, PATH, and LANG
+    # since those are required for such system calls. It will not pass on any
+    # other environment variables from the system.
+    #
+    # @return [Boolean]
+    #
+    attr_accessor :restricted_env
+
+    ##
     # If you don't want commands to take too long, you can set a timeout (in
     # seconds).
     #
@@ -73,6 +83,7 @@ module MiniMagick
       base.logger = Logger.new($stdout).tap { |l| l.level = Logger::INFO }
       base.warnings = true
       base.cli_env = {}.freeze
+      base.restricted_env = false
       base.graphicsmagick = false
     end
 

--- a/lib/mini_magick/shell.rb
+++ b/lib/mini_magick/shell.rb
@@ -27,11 +27,17 @@ module MiniMagick
     end
 
     def execute(command, stdin: "", timeout: MiniMagick.timeout)
-      env = {
-        'HOME' => ENV['HOME'],
-        'PATH' => ENV['PATH'],
-        'LANG' => ENV['LANG'],
-      }
+      env =
+        if MiniMagick.restricted_env
+          {
+            'HOME' => ENV['HOME'],
+            'PATH' => ENV['PATH'],
+            'LANG' => ENV['LANG'],
+          }
+        else
+          {}
+        end
+
       env.merge!(MiniMagick.cli_env)
       env["MAGICK_TIME_LIMIT"] = timeout.to_s if timeout
 

--- a/lib/mini_magick/shell.rb
+++ b/lib/mini_magick/shell.rb
@@ -27,12 +27,16 @@ module MiniMagick
     end
 
     def execute(command, stdin: "", timeout: MiniMagick.timeout)
-      env = {}
+      env = {
+        'HOME' => ENV['HOME'],
+        'PATH' => ENV['PATH'],
+        'LANG' => ENV['LANG'],
+      }
       env.merge!(MiniMagick.cli_env)
       env["MAGICK_TIME_LIMIT"] = timeout.to_s if timeout
 
       stdout, stderr, status = log(command.join(" ")) do
-        Open3.capture3(env, *command, stdin_data: stdin)
+        Open3.capture3(env, *command, stdin_data: stdin, unsetenv_others: MiniMagick.restricted_env)
       end
 
       [stdout, stderr, status&.exitstatus]

--- a/spec/lib/mini_magick/shell_spec.rb
+++ b/spec/lib/mini_magick/shell_spec.rb
@@ -96,9 +96,9 @@ RSpec.describe MiniMagick::Shell do
       stdout, * = subject.execute(['echo "SOMETHING_SECRET=$SOMETHING_SECRET HOME=$HOME PATH=$PATH"'])
 
       expect(stdout).to eq("SOMETHING_SECRET= HOME=#{Dir.home} PATH=/usr/bin\n")
-    ensure
-      ENV.delete('SOMETHING_SECRET')
     end
+
+    after { ENV.delete('SOMETHING_SECRET') }
 
     it "does not override the timeout if MAGICK_TIME_LIMIT is set in MiniMagick.cli_env" do
       allow(MiniMagick).to receive(:timeout).and_return(1)

--- a/spec/lib/mini_magick/shell_spec.rb
+++ b/spec/lib/mini_magick/shell_spec.rb
@@ -87,6 +87,19 @@ RSpec.describe MiniMagick::Shell do
       expect(stdout).to match("my value")
     end
 
+    it "executes the command with only the environment variables from MiniMagick.cli_env (plus some required env) when MiniMagick.restricted_env is true" do
+      allow(MiniMagick).to receive(:restricted_env).and_return(true)
+      allow(MiniMagick).to receive(:cli_env).and_return({"PATH" => "/usr/bin"})
+
+      ENV['SOMETHING_SECRET'] = 'abc123'
+
+      stdout, * = subject.execute(['echo "SOMETHING_SECRET=$SOMETHING_SECRET HOME=$HOME PATH=$PATH"'])
+
+      expect(stdout).to eq("SOMETHING_SECRET= HOME=#{Dir.home} PATH=/usr/bin\n")
+    ensure
+      ENV.delete('SOMETHING_SECRET')
+    end
+
     it "does not override the timeout if MAGICK_TIME_LIMIT is set in MiniMagick.cli_env" do
       allow(MiniMagick).to receive(:timeout).and_return(1)
       allow(MiniMagick).to receive(:cli_env).and_return({'MAGICK_TIME_LIMIT' => 'override'})

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,4 +8,10 @@ RSpec.configure do |config|
   config.formatter = "documentation"
   config.color = true
   config.fail_fast = true unless ENV["CI"]
+
+  config.mock_with :rspec do |mocks|
+    # Prevents you from mocking or stubbing a method that does not exist on
+    # a real object.
+    mocks.verify_partial_doubles = true
+  end
 end


### PR DESCRIPTION
Allows configuring Open3 to not pass in all other environment variables when making ImageMagick calls, to defend against any vulnerability that may appear in ImageMagick from gaining access to secret values in system env.

This requires explicitly passing in HOME, PATH, and LANG since ImageMagick needs those, and it builds upon the cli_env option.

Idea from: https://github.com/minimagick/minimagick/pull/449#issuecomment-378204956

Thanks for taking a look ☺️ 