### PR TITLE
Fix "ambiguous `*` has been interpreted as an argument prefix" warning

### DIFF
--- a/lib/mini_magick/tool.rb
+++ b/lib/mini_magick/tool.rb
@@ -121,11 +121,10 @@ module MiniMagick
     #   identify.executable #=> ["firejail", "--force", "magick", "identify"]
     #
     def executable
-      exe = [name]
-      exe.unshift "gm" if MiniMagick.graphicsmagick
-      exe.unshift "magick" if MiniMagick.imagemagick7? && name != "magick"
-      exe.unshift *Array(MiniMagick.cli_prefix)
-      exe
+      exe = Array(MiniMagick.cli_prefix)
+      exe << "magick" if MiniMagick.imagemagick7? && name != "magick"
+      exe << "gm" if MiniMagick.graphicsmagick
+      exe << name
     end
 
     ##


### PR DESCRIPTION
When running in verbose mode:

```
mini_magick-5.1.2/lib/mini_magick/tool.rb:127: warning: ambiguous `*` has been interpreted as an argument prefix
```