### PR TITLE
Fix testing with current versions of ImageMagick

### DIFF
--- a/spec/lib/mini_magick/shell_spec.rb
+++ b/spec/lib/mini_magick/shell_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe MiniMagick::Shell do
       stdout, stderr, status = subject.execute(%W[identify foo])
 
       expect(stdout).to eq ""
-      expect(stderr).to match("unable to open image")
+      expect(stderr).to match("(unable to open image|identify: no decode delegate for this image format)")
       expect(status).to eq 1
     end
 


### PR DESCRIPTION
I am the maintainer of the Debian package of MiniMagick.

https://tracker.debian.org/pkg/ruby-mini-magick

This pull request mirrors a local patch I am using to fix the error message in #590.