### PR TITLE
Drop `benchmark` dependency

### DIFF
--- a/lib/mini_magick/shell.rb
+++ b/lib/mini_magick/shell.rb
@@ -1,5 +1,4 @@
 require "open3"
-require "benchmark"
 
 module MiniMagick
   ##
@@ -43,8 +42,9 @@ module MiniMagick
     private
 
     def log(command, &block)
-      value = nil
-      duration = Benchmark.realtime { value = block.call }
+      time_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      value = block.call
+      duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - time_start
       MiniMagick.logger.debug "[%.2fs] %s" % [duration, command]
       value
     end

--- a/mini_magick.gemspec
+++ b/mini_magick.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.3'
 
   s.add_dependency 'logger'
-  s.add_dependency 'benchmark'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 3.5'


### PR DESCRIPTION
The following code is equivalent and works since Ruby 2.1