### PR TITLE
Fix option forwarding in MiniMagick::Tool.new

### DIFF
--- a/lib/mini_magick/tool.rb
+++ b/lib/mini_magick/tool.rb
@@ -27,8 +27,8 @@ module MiniMagick
     #   instance of the tool, if block is given, returns the output of the
     #   command.
     #
-    def self.new(*args)
-      instance = super(*args)
+    def self.new(*args, **options)
+      instance = super
 
       if block_given?
         yield instance

--- a/spec/lib/mini_magick/tool_spec.rb
+++ b/spec/lib/mini_magick/tool_spec.rb
@@ -30,6 +30,10 @@ RSpec.describe MiniMagick::Tool do
   end
 
   describe ".new" do
+    it "accepts options" do
+      expect { described_class.new("compare", errors: false) }.not_to raise_error
+    end
+
     it "accepts a block, and immediately executes the command" do
       output = described_class.new("identify") do |builder|
         builder << image_path(:gif)


### PR DESCRIPTION
`MiniMagick.compare(errors: false)` is erroring with `wrong number of arguments (given 2, expected 1) (ArgumentError)`

This appears to be due to MiniMagick::Tool.new not explicitly accepting kwargs, so it attempts to instantiate using two positonal args, which is not allowed.

This PR attempts to resolve the issue by updating the method signature of `MiniMagick::Tool.new` to accept kwargs.