### PR TITLE
Fix configured cli_prefix being muated

### DIFF
--- a/lib/mini_magick/tool.rb
+++ b/lib/mini_magick/tool.rb
@@ -121,7 +121,7 @@ module MiniMagick
     #   identify.executable #=> ["firejail", "--force", "magick", "identify"]
     #
     def executable
-      exe = Array(MiniMagick.cli_prefix)
+      exe = Array(MiniMagick.cli_prefix.dup)
       exe << "magick" if MiniMagick.imagemagick7? && name != "magick"
       exe << "gm" if MiniMagick.graphicsmagick
       exe << name

--- a/spec/lib/mini_magick/tool_spec.rb
+++ b/spec/lib/mini_magick/tool_spec.rb
@@ -70,9 +70,11 @@ RSpec.describe MiniMagick::Tool do
     end
 
     it "respects #cli_prefix as an array" do
+      prefix = ['firejail', '--force']
       allow(MiniMagick).to receive(:imagemagick7?).and_return(false)
-      allow(MiniMagick).to receive(:cli_prefix).and_return(['firejail', '--force'])
+      allow(MiniMagick).to receive(:cli_prefix).and_return(prefix)
       expect(subject.executable).to eq %W[firejail --force identify]
+      expect(prefix).to eq(['firejail', '--force'])
     end
   end
 


### PR DESCRIPTION
When `cli_prefix` was configured as an array building the executable mutated the configured prefix to include the executable itself.